### PR TITLE
Phase 2: install/remove via npx skills + venv bin symlinks

### DIFF
--- a/genotools/commands.py
+++ b/genotools/commands.py
@@ -1,10 +1,23 @@
-"""Subcommand dispatch. Most handlers are stubs until later phases land."""
+"""Subcommand dispatch + handler implementations."""
+
+from __future__ import annotations
 
 import argparse
+import os
+import shutil
+import subprocess
 import sys
+import tomllib
+from pathlib import Path
 
 from genotools import paths, registry
 
+
+# Where venv binaries get symlinked so SKILL.md can call them as bare names.
+SYSTEM_BIN = Path.home() / ".local" / "bin"
+
+
+# ── Dispatch ────────────────────────────────────────────────────────────────
 
 def dispatch(args: argparse.Namespace) -> int:
     handlers = {
@@ -20,6 +33,8 @@ def dispatch(args: argparse.Namespace) -> int:
     }
     return handlers[args.cmd](args)
 
+
+# ── ls ──────────────────────────────────────────────────────────────────────
 
 def _ls(args: argparse.Namespace) -> int:
     if args.available:
@@ -47,11 +62,261 @@ def _ls(args: argparse.Namespace) -> int:
     return 0
 
 
+# ── install ─────────────────────────────────────────────────────────────────
+
 def _install(args: argparse.Namespace) -> int:
     if args.here:
         return _todo(f"install --here {args.name}: cwd alias materialization")
-    return _todo(f"install {args.name}: clone, worktree, venv, skill install (npx skills)")
 
+    source, name = _resolve_source(args.name)
+    if name is None:
+        name = _peek_repo_name(source)
+    full = paths.normalize(name)
+
+    if paths.skillset_root(full).exists():
+        print(f"already installed: {full} "
+              f"(remove first: geno-tools remove {paths.short(full)})", file=sys.stderr)
+        return 1
+
+    print(f"installing {full} from {source}")
+    root = paths.skillset_root(full)
+    root.mkdir(parents=True)
+    try:
+        _clone_and_worktree(source, full)
+        scripts = _create_venv_if_needed(full)
+        _materialize_bin_symlinks(full, scripts)
+        paths.skillset_active(full).symlink_to("main")
+        _install_skills_via_npx(full)
+    except Exception:
+        shutil.rmtree(root, ignore_errors=True)
+        raise
+
+    print(f"✓ installed {full}")
+    return 0
+
+
+# ── remove ──────────────────────────────────────────────────────────────────
+
+def _remove(args: argparse.Namespace) -> int:
+    full = paths.normalize(args.name)
+    root = paths.skillset_root(full)
+    if not root.exists():
+        print(f"not installed: {full}", file=sys.stderr)
+        return 1
+
+    _uninstall_skills_via_npx(full)
+    _remove_bin_symlinks(full)
+
+    if args.keep_data:
+        for child in root.iterdir():
+            if child.name in ("venvs", ".worktrees"):
+                continue
+            if child.is_symlink() or child.is_file():
+                child.unlink()
+            else:
+                shutil.rmtree(child, ignore_errors=True)
+    else:
+        shutil.rmtree(root, ignore_errors=True)
+
+    print(f"removed {full}")
+    return 0
+
+
+# ── source resolution ───────────────────────────────────────────────────────
+
+def _resolve_source(name_or_source: str) -> tuple[str, str | None]:
+    """Return (source, known_name). Known_name is set only for registry hits."""
+    url = registry.resolve(name_or_source)
+    if url:
+        return url, name_or_source
+
+    p = Path(name_or_source).expanduser()
+    if p.exists() and p.is_dir():
+        return str(p.resolve()), None
+
+    if name_or_source.startswith(("http://", "https://", "git@")) \
+       or name_or_source.endswith(".git"):
+        return name_or_source, None
+
+    raise SystemExit(
+        f"unknown skillset: {name_or_source} (not in registry, not a path, not a git URL)"
+    )
+
+
+def _peek_repo_name(source: str) -> str:
+    """Determine the canonical skillset name from a source URL or path.
+
+    Priority:
+      1. pyproject.toml [project].name (cloned shallow if remote)
+      2. Repo basename (URL tail or directory name)
+    """
+    p = Path(source)
+    if p.exists() and p.is_dir():
+        name = _read_pyproject_name(p)
+        return name or p.name
+
+    # Remote URL: shallow clone to staging.
+    staging = paths.ROOT / ".staging"
+    if staging.exists():
+        shutil.rmtree(staging)
+    staging.mkdir(parents=True)
+    try:
+        subprocess.check_call(
+            ["git", "clone", "--depth", "1", "--quiet", source, str(staging / "repo")]
+        )
+        name = _read_pyproject_name(staging / "repo")
+        if name:
+            return name
+        # Fall back to URL tail
+        return source.rstrip("/").rsplit("/", 1)[-1].removesuffix(".git")
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+def _read_pyproject_name(repo_dir: Path) -> str | None:
+    pj = repo_dir / "pyproject.toml"
+    if not pj.exists():
+        return None
+    try:
+        data = tomllib.loads(pj.read_text())
+    except tomllib.TOMLDecodeError:
+        return None
+    return (data.get("project") or {}).get("name")
+
+
+# ── git ─────────────────────────────────────────────────────────────────────
+
+def _clone_and_worktree(source: str, full: str) -> None:
+    bare = paths.skillset_git(full)
+    subprocess.check_call(["git", "clone", "--bare", "--quiet", source, str(bare)])
+
+    default_branch = _detect_default_branch(bare)
+    subprocess.check_call([
+        "git", "-C", str(bare), "worktree", "add",
+        str(paths.skillset_worktree(full, "main")), default_branch,
+    ])
+
+
+def _detect_default_branch(bare_repo: Path) -> str:
+    out = subprocess.check_output(
+        ["git", "-C", str(bare_repo), "symbolic-ref", "--short", "HEAD"],
+        text=True,
+    ).strip()
+    return out or "main"
+
+
+# ── venv ────────────────────────────────────────────────────────────────────
+
+def _create_venv_if_needed(full: str) -> dict[str, str]:
+    """Create venv + editable install if the worktree has a Python project.
+
+    Returns a dict of {script_name: script_target} from [project.scripts],
+    or {} if no Python project.
+    """
+    worktree = paths.skillset_worktree(full, "main")
+    pyproject = worktree / "pyproject.toml"
+    if not pyproject.exists():
+        return {}
+
+    data = tomllib.loads(pyproject.read_text())
+    project = data.get("project", {})
+    deps = project.get("dependencies", []) or []
+    scripts = project.get("scripts", {}) or {}
+
+    # If no [project] table at all, skip venv.
+    if not project:
+        return {}
+
+    venv_dir = paths.skillset_venvs(full) / "default"
+    venv_dir.parent.mkdir(parents=True, exist_ok=True)
+    print(f"  creating venv: {venv_dir}")
+    subprocess.check_call([sys.executable, "-m", "venv", str(venv_dir)])
+
+    pip = venv_dir / "bin" / "pip"
+    subprocess.check_call([str(pip), "install", "--quiet", "--upgrade", "pip"])
+
+    if deps:
+        print(f"  installing deps: {', '.join(deps)}")
+        subprocess.check_call([str(pip), "install", "--quiet", *deps])
+
+    # Editable install of the project itself materializes [project.scripts] binaries.
+    print(f"  installing package (editable)")
+    subprocess.check_call([str(pip), "install", "--quiet", "-e", str(worktree)])
+
+    return scripts
+
+
+def _materialize_bin_symlinks(full: str, scripts: dict[str, str]) -> None:
+    """Symlink each [project.scripts] entry into ~/.local/bin/."""
+    if not scripts:
+        return
+    SYSTEM_BIN.mkdir(parents=True, exist_ok=True)
+    venv_bin = paths.skillset_venvs(full) / "default" / "bin"
+    for name in scripts:
+        src = venv_bin / name
+        if not src.exists():
+            print(f"  warn: expected venv binary not found: {src}", file=sys.stderr)
+            continue
+        dst = SYSTEM_BIN / name
+        if dst.is_symlink() or dst.exists():
+            existing = dst.readlink() if dst.is_symlink() else None
+            if existing == src:
+                continue  # already correct
+            print(f"  warn: {dst} already exists; skipping", file=sys.stderr)
+            continue
+        dst.symlink_to(src)
+        print(f"  ↳ {dst} -> {src}")
+
+
+def _remove_bin_symlinks(full: str) -> None:
+    """Drop ~/.local/bin/ symlinks that point into this skillset's venv."""
+    if not SYSTEM_BIN.exists():
+        return
+    venv_bin = paths.skillset_venvs(full) / "default" / "bin"
+    for entry in SYSTEM_BIN.iterdir():
+        if not entry.is_symlink():
+            continue
+        try:
+            target = entry.readlink()
+        except OSError:
+            continue
+        # Resolve to absolute for comparison
+        target_abs = (entry.parent / target).resolve()
+        if str(target_abs).startswith(str(venv_bin)):
+            entry.unlink()
+            print(f"  ↳ removed {entry}")
+
+
+# ── npx skills ──────────────────────────────────────────────────────────────
+
+def _install_skills_via_npx(full: str) -> None:
+    active = paths.skillset_active(full)
+    print(f"  installing skills via npx skills (claude-code, global)")
+    subprocess.check_call([
+        "npx", "--yes", "skills", "add", str(active),
+        "--agent", "claude-code", "--global", "--skill", "*", "--yes",
+    ])
+
+
+def _uninstall_skills_via_npx(full: str) -> None:
+    skill_names = _enumerate_skills(full)
+    if not skill_names:
+        return
+    print(f"  uninstalling {len(skill_names)} skill(s) via npx skills")
+    cmd = ["npx", "--yes", "skills", "remove", "--global", "--yes", *skill_names]
+    subprocess.run(cmd, check=False)
+
+
+def _enumerate_skills(full: str) -> list[str]:
+    """Return skill folder names in the active worktree's skills/ dir."""
+    skills_dir = paths.skillset_active(full) / "skills"
+    if not skills_dir.exists():
+        return []
+    return sorted(p.name for p in skills_dir.iterdir()
+                  if p.is_dir() and (p / "SKILL.md").exists())
+
+
+# ── stubs (later phases) ────────────────────────────────────────────────────
 
 def _dev(args: argparse.Namespace) -> int:
     return _todo(f"dev {args.name} {args.path}: symlink local checkout as main worktree")
@@ -74,11 +339,6 @@ def _promote(args: argparse.Namespace) -> int:
 def _update(args: argparse.Namespace) -> int:
     target = args.name or "<all>"
     return _todo(f"update {target}: git pull on main worktree")
-
-
-def _remove(args: argparse.Namespace) -> int:
-    flag = " --keep-data" if args.keep_data else ""
-    return _todo(f"remove {args.name}{flag}: uninstall skill, drop ~/.geno-tools/geno-{args.name}/")
 
 
 def _doctor(_: argparse.Namespace) -> int:


### PR DESCRIPTION
## Summary

Implements the first end-to-end install/remove pipeline. Uses \`npx skills\` as the multi-agent skill installation backend, with geno-tools handling everything else (venv, binary PATH symlinks, worktree management).

**Stacked on #5** (foundation). Auto-retargets to main when #5 merges.

## What works

\`\`\`
$ geno-tools install /path/to/geno-agents       # or just `geno-tools install agents` once on remote main
installing geno-agents from /path/to/geno-agents
  creating venv: ~/.geno-tools/geno-agents/venvs/default
  installing deps: click>=8.0
  installing package (editable)
  ↳ ~/.local/bin/geno-agents -> ~/.geno-tools/geno-agents/venvs/default/bin/geno-agents
  installing skills via npx skills (claude-code, global)
✓ installed geno-agents

$ geno-tools ls
  geno-agents              active: main

$ geno-tools remove agents
  uninstalling 3 skill(s) via npx skills
  ↳ removed ~/.local/bin/geno-agents
removed geno-agents
\`\`\`

After install, Claude Code immediately picks up the 3 geno-agents skills and \`geno-agents\` is on PATH for SKILL.md to invoke.

## How it works

1. **Clone & worktree** — \`git clone --bare\` into \`~/.geno-tools/geno-{name}/.git\`, then \`git worktree add main\`
2. **Venv** (if \`pyproject.toml\` has \`[project]\`):
   - Create venv at \`~/.geno-tools/geno-{name}/venvs/default/\`
   - Install \`[project].dependencies\`
   - Editable install of the package itself so \`[project.scripts]\` binaries materialize
3. **Bin PATH symlinks** — for each \`[project.scripts]\` entry, symlink \`~/.local/bin/<name>\` → \`<venv>/bin/<name>\` (replaces the plugin \`bin/\` mechanism we lost when going skills-only)
4. **active → main** symlink (laid down for future variant management via \`fork\`/\`use\`)
5. **\`npx skills add <active> --agent claude-code --global --skill '*' --yes\`** — fans every \`SKILL.md\` folder into \`~/.claude/skills/\`

Source resolution accepts: registry short name, local path, or git URL. Repo name is determined from \`pyproject.toml\` \`[project].name\` if present, falling back to the URL/dir basename.

Remove is the reverse — enumerate skills in the active worktree, \`npx skills remove\` each, drop any \`~/.local/bin/\` symlinks pointing into our venv, and \`rmtree\` the skillset root.

## Tested end-to-end against geno-agents

Depends on geno-agents PR https://github.com/42euge/geno-agents/pull/4 being merged (or installed from a local checkout). All three skills register, the CLI binary works, and \`geno-tools remove\` cleans everything.

## Limitations / follow-ups

- **\`npx skills\` defaults to copy mode**, not symlink. Live worktree edits don't propagate. For the meta-harness variant testing loop, we'll need to either pass an explicit symlink flag or wait for a re-install. Will revisit once \`fork\`/\`use\` land.
- **Bin symlink collisions** — if \`~/.local/bin/<name>\` already exists pointing somewhere else, we skip with a warning rather than overwriting. Conservative; reconsider after multi-skillset install scenarios.
- **\`[project.scripts]\` in venv only** — we don't surface other tooling (e.g. shell scripts in the repo's \`bin/\`). If geno-* repos need that, add an opt-in extension to a future \`genotools.yaml\` manifest.

## What's still stubbed

\`dev\`, \`fork\`, \`use\`, \`promote\`, \`update\`, \`doctor\`, \`install --here\` — all return \`[not yet implemented]\`. Each gets its own follow-up PR.

## Test plan

- [x] \`geno-tools install <local geno-agents>\` succeeds end-to-end
- [x] 3 skills register in \`~/.claude/skills/\` and are visible to Claude
- [x] \`geno-agents\` CLI works on PATH (\`/Users/euge/.local/bin/geno-agents\`)
- [x] \`geno-tools ls\` shows the install + active variant
- [x] \`geno-tools remove agents\` cleans everything
- [ ] Once #4 in geno-agents merges to main: \`geno-tools install agents\` (registry name) works against the URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)