### PR TITLE
Phase 3: variant management — fork + use

### DIFF
--- a/genotools/commands.py
+++ b/genotools/commands.py
@@ -316,20 +316,131 @@ def _enumerate_skills(full: str) -> list[str]:
                   if p.is_dir() and (p / "SKILL.md").exists())
 
 
+# ── fork ────────────────────────────────────────────────────────────────────
+
+def _fork(args: argparse.Namespace) -> int:
+    full = paths.normalize(args.name)
+    if not paths.skillset_root(full).exists():
+        print(f"not installed: {full}", file=sys.stderr)
+        return 1
+
+    variant = args.variant
+    if variant in ("main", "active"):
+        print(f"reserved variant name: {variant}", file=sys.stderr)
+        return 1
+
+    worktree = paths.skillset_worktree(full, variant)
+    if worktree.exists():
+        print(f"variant already exists: {full}@{variant}", file=sys.stderr)
+        return 1
+
+    bare = paths.skillset_git(full)
+    print(f"forking {full}@{variant}")
+    subprocess.check_call([
+        "git", "-C", str(bare), "worktree", "add", "-b", variant, str(worktree),
+    ])
+
+    if args.isolated_venv:
+        _create_venv_for_variant(full, variant, worktree)
+
+    print(f"✓ forked {full}@{variant}")
+    return 0
+
+
+def _create_venv_for_variant(full: str, variant: str, worktree: Path) -> None:
+    pyproject = worktree / "pyproject.toml"
+    if not pyproject.exists():
+        print(f"  no pyproject.toml; skipping venv")
+        return
+    data = tomllib.loads(pyproject.read_text())
+    project = data.get("project", {})
+    deps = project.get("dependencies", []) or []
+    if not project:
+        return
+
+    venv_dir = paths.skillset_venvs(full) / variant
+    print(f"  creating isolated venv: {venv_dir}")
+    subprocess.check_call([sys.executable, "-m", "venv", str(venv_dir)])
+    pip = venv_dir / "bin" / "pip"
+    subprocess.check_call([str(pip), "install", "--quiet", "--upgrade", "pip"])
+    if deps:
+        subprocess.check_call([str(pip), "install", "--quiet", *deps])
+    subprocess.check_call([str(pip), "install", "--quiet", "-e", str(worktree)])
+
+
+# ── use ─────────────────────────────────────────────────────────────────────
+
+def _use(args: argparse.Namespace) -> int:
+    name, sep, variant = args.spec.partition("@")
+    if not sep or not variant:
+        print(f"expected <name>@<variant>, got: {args.spec}", file=sys.stderr)
+        return 1
+    full = paths.normalize(name)
+
+    if not paths.skillset_root(full).exists():
+        print(f"not installed: {full}", file=sys.stderr)
+        return 1
+
+    if args.here:
+        return _todo(f"use --here {args.spec}: cwd alias materialization (Phase 4)")
+
+    target_path = paths.skillset_worktree(full, variant)
+    if not target_path.exists():
+        print(f"variant not found: {full}@{variant}", file=sys.stderr)
+        return 1
+
+    # Determine the relative target for the active symlink.
+    target_rel = "main" if variant == "main" else f".worktrees/{variant}"
+
+    active = paths.skillset_active(full)
+    if active.is_symlink() or active.exists():
+        active.unlink()
+    active.symlink_to(target_rel)
+
+    # If the variant has its own venv, repoint ~/.local/bin/ symlinks to it.
+    variant_venv = paths.skillset_venvs(full) / variant
+    if variant_venv.exists():
+        _repoint_bin_symlinks(full, variant)
+    # else: shared venv — bin symlinks already point at venvs/default/, no change needed.
+
+    # Refresh skill installs (npx skills copies, doesn't symlink, so we need to re-add).
+    _install_skills_via_npx(full)
+
+    print(f"✓ active variant for {full}: {variant}")
+    return 0
+
+
+def _repoint_bin_symlinks(full: str, variant: str) -> None:
+    """Replace ~/.local/bin/ symlinks pointing into another venv with this variant's."""
+    if not SYSTEM_BIN.exists():
+        return
+    venvs_root = paths.skillset_venvs(full)
+    target_bin = venvs_root / variant / "bin"
+    if not target_bin.exists():
+        return
+
+    for entry in SYSTEM_BIN.iterdir():
+        if not entry.is_symlink():
+            continue
+        try:
+            link_target = (entry.parent / entry.readlink()).resolve()
+        except OSError:
+            continue
+        # If the symlink already points into this skillset's venvs/, repoint to the variant.
+        if not str(link_target).startswith(str(venvs_root.resolve())):
+            continue
+        new_target = target_bin / entry.name
+        if not new_target.exists():
+            continue
+        entry.unlink()
+        entry.symlink_to(new_target)
+        print(f"  ↳ repointed {entry} -> {new_target}")
+
+
 # ── stubs (later phases) ────────────────────────────────────────────────────
 
 def _dev(args: argparse.Namespace) -> int:
     return _todo(f"dev {args.name} {args.path}: symlink local checkout as main worktree")
-
-
-def _fork(args: argparse.Namespace) -> int:
-    return _todo(f"fork {args.name} {args.variant}: git worktree add"
-                 + (" + isolated venv" if args.isolated_venv else ""))
-
-
-def _use(args: argparse.Namespace) -> int:
-    scope = "cwd" if args.here else "global"
-    return _todo(f"use {args.spec} ({scope}): repoint active or cwd alias")
 
 
 def _promote(args: argparse.Namespace) -> int:


### PR DESCRIPTION
## Summary

Adds the meta-harness primitives. Each skillset already has a bare git repo and main worktree (Phase 2); this PR lets you spin up additional worktrees as named variants and swap which one Claude Code sees.

**Stacked on #5/#6.** Auto-retargets up the chain as those merge.

## What works

\`\`\`bash
$ geno-tools install agents                # main worktree, default venv
$ geno-tools fork agents exp-1             # new worktree on branch exp-1
$ geno-tools fork agents big-refactor --isolated-venv   # variant w/ its own venv

$ geno-tools use agents@exp-1              # repoint active -> exp-1, refresh skills
✓ active variant for geno-agents: exp-1

$ geno-tools use agents@main               # back to main
✓ active variant for geno-agents: main

$ geno-tools ls
  geno-agents              active: main

$ geno-tools remove agents                 # cleans main + all variants + bin symlinks
\`\`\`

## How it works

### \`fork <name> <variant> [--isolated-venv]\`

- \`git worktree add -b <variant>\` under \`.worktrees/<variant>/\` — variant gets its own branch off the bare repo
- \`--isolated-venv\` (opt-in): create \`venvs/<variant>/\` and editable-install the variant's pyproject. Use when a variant changes Python code or deps.
- Default (shared venv): variants share \`venvs/default/\`. Fine when variants only edit SKILL.md / instructions.

### \`use <name>@<variant>\` (global; \`--here\` is Phase 4)

1. Repoint \`~/.geno-tools/geno-{name}/active\` → \`.worktrees/<variant>\` (or \`main\`)
2. If the variant has its own venv, repoint \`~/.local/bin/<entry>\` symlinks to the variant's venv binaries
3. Re-run \`npx skills add <active>\` to refresh \`~/.claude/skills/\` content

Step 3 is necessary because \`npx skills\` currently uses copy mode (not symlink), so without re-adding, Claude would still see the previous variant's content. Once we figure out how to coax \`npx skills\` into symlink mode, this becomes a no-op.

## Tested empirically

1. Install agents from local geno-agents
2. Fork \`exp-1\`
3. Append \`<!-- VARIANT MARKER: exp-1 -->\` to the variant's \`skills/geno-agents/SKILL.md\`
4. \`use agents@exp-1\` → verified \`~/.claude/skills/geno-agents/SKILL.md\` now has the marker
5. \`use agents@main\` → verified the marker is gone

This is the meta-harness loop primitive: edit a worktree, swap to it, run an evaluation, swap back.

## Edge cases handled

- Reserved variant names (\`main\`, \`active\`) rejected at \`fork\` time
- \`use\` validates the variant exists before touching anything
- \`use\` errors cleanly if the skillset isn't installed
- \`remove\` tears down all worktrees + all venvs + all bin symlinks (git worktree handles the worktree cleanup as part of \`shutil.rmtree\` on the skillset root, since the bare repo goes too)

## Still stubbed (follow-up PRs)

- \`install --here\` — cwd alias materialization (Phase 4)
- \`use --here\` — cwd-only variant override (Phase 4)
- \`dev\`, \`promote\`, \`update\`, \`doctor\` (Phase 5)

## Test plan

- [x] \`fork\` creates worktree on new branch
- [x] \`fork --isolated-venv\` creates a fresh venv
- [x] \`use <name>@<variant>\` swaps active + refreshes skills
- [x] \`use <name>@main\` swaps back
- [x] Marker test: variant content reaches \`~/.claude/skills/\`
- [x] \`remove\` cleans variants + main + venvs + bin symlinks
- [ ] Awaiting PR chain merge to test from registry URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)