### PR TITLE
Phase 4: cwd alias bootstrap + install --here + use --here

### DIFF
--- a/genotools/bootstrap.py
+++ b/genotools/bootstrap.py
@@ -1,0 +1,190 @@
+"""SessionStart hook bootstrap + cwd alias materialization.
+
+The gt-bootstrap.sh script is written to ~/.geno-tools/ on first install
+and called via Claude Code's SessionStart hook.  It materializes short
+`gt-{rest}` aliases in `<cwd>/.claude/skills/` that symlink to the
+globally-installed `geno-{tool}-{rest}` skills.
+
+The hook entry is managed in ~/.claude/settings.json by geno-tools.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from genotools import paths
+
+SETTINGS_FILE = Path.home() / ".claude" / "settings.json"
+BOOTSTRAP_SCRIPT = paths.ROOT / "gt-bootstrap.sh"
+HOOK_MARKER = "gt-bootstrap"  # substring to find our hook entry
+
+BOOTSTRAP_SH = r'''#!/bin/bash
+# geno-tools SessionStart hook: materialize /gt-* aliases in cwd.
+# Only runs if <cwd>/.claude/ exists (project is Claude-aware).
+
+GENO_ROOT="$HOME/.geno-tools"
+CWD_SKILLS=".claude/skills"
+
+[ -d ".claude" ] || exit 0
+mkdir -p "$CWD_SKILLS" 2>/dev/null || exit 0
+
+for skillset_dir in "$GENO_ROOT"/geno-*/; do
+    [ -d "$skillset_dir" ] || continue
+    active="$skillset_dir/active"
+    [ -L "$active" ] || continue
+    skills_dir="$(cd "$active" 2>/dev/null && pwd)/skills"
+    [ -d "$skills_dir" ] || continue
+
+    skillset_name=$(basename "$skillset_dir")
+    tool="${skillset_name#geno-}"
+
+    for skill_dir in "$skills_dir"/*/; do
+        [ -d "$skill_dir" ] || continue
+        [ -f "$skill_dir/SKILL.md" ] || continue
+
+        skill_name=$(basename "$skill_dir")
+
+        if [ "$skill_name" = "$skillset_name" ]; then
+            alias_name="gt-${tool}"
+        else
+            rest="${skill_name#${skillset_name}-}"
+            if [ "$rest" != "$skill_name" ]; then
+                alias_name="gt-${rest}"
+            else
+                alias_name="gt-${skill_name}"
+            fi
+        fi
+
+        alias_target="$CWD_SKILLS/$alias_name"
+        [ -e "$alias_target" ] || [ -L "$alias_target" ] && continue
+        ln -s "$skill_dir" "$alias_target"
+    done
+done
+'''
+
+
+def write_bootstrap_script() -> None:
+    BOOTSTRAP_SCRIPT.parent.mkdir(parents=True, exist_ok=True)
+    BOOTSTRAP_SCRIPT.write_text(BOOTSTRAP_SH)
+    BOOTSTRAP_SCRIPT.chmod(0o755)
+
+
+def ensure_hook_registered() -> None:
+    """Add the SessionStart hook to ~/.claude/settings.json if missing."""
+    write_bootstrap_script()
+
+    if not SETTINGS_FILE.exists():
+        SETTINGS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        settings: dict = {}
+    else:
+        settings = json.loads(SETTINGS_FILE.read_text())
+
+    hooks = settings.setdefault("hooks", {})
+    session_start = hooks.setdefault("SessionStart", [])
+
+    for group in session_start:
+        for h in group.get("hooks", []):
+            if HOOK_MARKER in h.get("command", ""):
+                return  # already registered
+
+    session_start.append({
+        "hooks": [{
+            "type": "command",
+            "command": str(BOOTSTRAP_SCRIPT),
+            "timeout": 5,
+        }],
+    })
+
+    SETTINGS_FILE.write_text(json.dumps(settings, indent=2) + "\n")
+
+
+def remove_hook() -> None:
+    """Remove the SessionStart hook from ~/.claude/settings.json."""
+    if not SETTINGS_FILE.exists():
+        return
+    settings = json.loads(SETTINGS_FILE.read_text())
+    session_start = settings.get("hooks", {}).get("SessionStart", [])
+    filtered = [
+        group for group in session_start
+        if not any(HOOK_MARKER in h.get("command", "") for h in group.get("hooks", []))
+    ]
+    if len(filtered) != len(session_start):
+        settings["hooks"]["SessionStart"] = filtered
+        SETTINGS_FILE.write_text(json.dumps(settings, indent=2) + "\n")
+
+    if BOOTSTRAP_SCRIPT.exists():
+        BOOTSTRAP_SCRIPT.unlink()
+
+
+def materialize_cwd_aliases(skillsets: list[str] | None = None) -> int:
+    """Materialize gt-* aliases in <cwd>/.claude/skills/ for the given skillsets.
+
+    If skillsets is None, do all installed. This is the Python equivalent of
+    gt-bootstrap.sh, used by `install --here` and `use --here`.
+    """
+    cwd_skills = Path.cwd() / ".claude" / "skills"
+    cwd_skills.mkdir(parents=True, exist_ok=True)
+
+    if skillsets is None:
+        if not paths.ROOT.exists():
+            return 0
+        skillsets = [
+            p.name for p in paths.ROOT.iterdir()
+            if p.is_dir() and p.name.startswith("geno-")
+        ]
+
+    count = 0
+    for full in skillsets:
+        active = paths.skillset_active(full)
+        if not active.is_symlink():
+            continue
+        # Resolve for iteration (to see what skill dirs exist).
+        resolved_skills = (active.resolve()) / "skills"
+        if not resolved_skills.exists():
+            continue
+
+        tool = paths.short(full)
+
+        for skill_dir in sorted(resolved_skills.iterdir()):
+            if not skill_dir.is_dir() or not (skill_dir / "SKILL.md").exists():
+                continue
+
+            skill_name = skill_dir.name
+            if skill_name == full:
+                alias = f"gt-{tool}"
+            else:
+                rest = skill_name.removeprefix(f"{full}-")
+                alias = f"gt-{rest}" if rest != skill_name else f"gt-{skill_name}"
+
+            alias_path = cwd_skills / alias
+            if alias_path.exists() or alias_path.is_symlink():
+                continue
+
+            # Point through `active` (not resolved) so global `use` propagates.
+            alias_path.symlink_to(active / "skills" / skill_name)
+            print(f"  ↳ {alias} -> {skill_name}")
+            count += 1
+
+    return count
+
+
+def remove_cwd_aliases(full: str) -> None:
+    """Remove gt-* aliases in <cwd>/.claude/skills/ that point into this skillset."""
+    cwd_skills = Path.cwd() / ".claude" / "skills"
+    if not cwd_skills.exists():
+        return
+    active = paths.skillset_active(full)
+    if not active.is_symlink():
+        return
+    skillset_path = str(active.resolve())
+    for entry in cwd_skills.iterdir():
+        if not entry.is_symlink():
+            continue
+        try:
+            target = str(entry.resolve())
+        except OSError:
+            continue
+        if target.startswith(skillset_path):
+            entry.unlink()
+            print(f"  ↳ removed cwd alias {entry.name}")

--- a/genotools/commands.py
+++ b/genotools/commands.py
@@ -10,7 +10,7 @@ import sys
 import tomllib
 from pathlib import Path
 
-from genotools import paths, registry
+from genotools import bootstrap, paths, registry
 
 
 # Where venv binaries get symlinked so SKILL.md can call them as bare names.
@@ -66,7 +66,14 @@ def _ls(args: argparse.Namespace) -> int:
 
 def _install(args: argparse.Namespace) -> int:
     if args.here:
-        return _todo(f"install --here {args.name}: cwd alias materialization")
+        full = paths.normalize(args.name)
+        if not paths.skillset_root(full).exists():
+            print(f"not installed globally: {full} "
+                  f"(install first: geno-tools install {paths.short(full)})", file=sys.stderr)
+            return 1
+        n = bootstrap.materialize_cwd_aliases([full])
+        print(f"✓ materialized {n} alias(es) in <cwd>/.claude/skills/")
+        return 0
 
     source, name = _resolve_source(args.name)
     if name is None:
@@ -87,6 +94,7 @@ def _install(args: argparse.Namespace) -> int:
         _materialize_bin_symlinks(full, scripts)
         paths.skillset_active(full).symlink_to("main")
         _install_skills_via_npx(full)
+        bootstrap.ensure_hook_registered()
     except Exception:
         shutil.rmtree(root, ignore_errors=True)
         raise
@@ -104,6 +112,7 @@ def _remove(args: argparse.Namespace) -> int:
         print(f"not installed: {full}", file=sys.stderr)
         return 1
 
+    bootstrap.remove_cwd_aliases(full)
     _uninstall_skills_via_npx(full)
     _remove_bin_symlinks(full)
 
@@ -117,6 +126,14 @@ def _remove(args: argparse.Namespace) -> int:
                 shutil.rmtree(child, ignore_errors=True)
     else:
         shutil.rmtree(root, ignore_errors=True)
+
+    # If no skillsets remain, remove the SessionStart hook.
+    remaining = [
+        p.name for p in paths.ROOT.iterdir()
+        if p.is_dir() and p.name.startswith("geno-")
+    ] if paths.ROOT.exists() else []
+    if not remaining:
+        bootstrap.remove_hook()
 
     print(f"removed {full}")
     return 0
@@ -388,7 +405,34 @@ def _use(args: argparse.Namespace) -> int:
         return 1
 
     if args.here:
-        return _todo(f"use --here {args.spec}: cwd alias materialization (Phase 4)")
+        target_path = paths.skillset_worktree(full, variant)
+        if not target_path.exists():
+            print(f"variant not found: {full}@{variant}", file=sys.stderr)
+            return 1
+        # Remove existing cwd aliases for this skillset, then re-materialize
+        # pointing at the variant's skills.
+        bootstrap.remove_cwd_aliases(full)
+        cwd_skills = Path.cwd() / ".claude" / "skills"
+        cwd_skills.mkdir(parents=True, exist_ok=True)
+        skills_dir = target_path / "skills"
+        if skills_dir.exists():
+            tool = paths.short(full)
+            for skill_dir in sorted(skills_dir.iterdir()):
+                if not skill_dir.is_dir() or not (skill_dir / "SKILL.md").exists():
+                    continue
+                skill_name = skill_dir.name
+                if skill_name == full:
+                    alias = f"gt-{tool}"
+                else:
+                    rest = skill_name.removeprefix(f"{full}-")
+                    alias = f"gt-{rest}" if rest != skill_name else f"gt-{skill_name}"
+                alias_path = cwd_skills / alias
+                if alias_path.is_symlink() or alias_path.exists():
+                    alias_path.unlink()
+                alias_path.symlink_to(skill_dir.resolve())
+                print(f"  ↳ {alias} -> {skill_name} (variant: {variant})")
+        print(f"✓ cwd aliases for {full}: {variant}")
+        return 0
 
     target_path = paths.skillset_worktree(full, variant)
     if not target_path.exists():


### PR DESCRIPTION
## Summary

The meta-harness completer. Adds per-cwd alias materialization so different working directories can test different skill variants simultaneously via \`/gt-*\` short names, while global \`/geno-*\` skills remain stable.

**Stacked on PR #8 (phase5-quality-of-life).**

## How it works

### SessionStart hook

On first \`geno-tools install\`, a \`gt-bootstrap.sh\` script is written to \`~/.geno-tools/\` and registered as a SessionStart hook in \`~/.claude/settings.json\`. Each new Claude session:

1. Checks if \`<cwd>/.claude/\` exists (only Claude-aware projects get aliases)
2. For each installed geno-* skillset, creates \`<cwd>/.claude/skills/gt-{rest}/\` symlinks through the \`active\` symlink
3. Aliases follow \`active\`, so global \`use\` propagates to new sessions automatically

### \`install --here <name>\`

Manual alias materialization — same as what the hook does, but explicit. Run once per project.

### \`use <name>@<variant> --here\`

Per-cwd variant override. Points cwd aliases DIRECTLY at the variant worktree (not through \`active\`). This makes the cwd independent of the global state — the parallel meta-harness primitive.

### Naming

| Scope | Skill name | Points to |
|---|---|---|
| Global (\`~/.claude/skills/\`) | \`/geno-agents-tasks-start\` | Current \`active\` (main or whatever global \`use\` set) |
| CWD (\`<cwd>/.claude/skills/\`) | \`/gt-tasks-start\` | Either \`active\` (via \`install --here\`) or a specific variant (via \`use --here\`) |

Different names → no precedence conflict. Both available in the same session.

## Demo

\`\`\`bash
$ geno-tools install agents             # global install + hook registered
$ geno-tools install --here agents      # materialize cwd aliases
  ↳ gt-agents -> geno-agents
  ↳ gt-supercharge -> geno-agents-supercharge
  ↳ gt-tasks-start -> geno-agents-tasks-start

$ geno-tools fork agents exp-1
$ geno-tools use agents@exp-1 --here    # cwd aliases → variant
  ↳ gt-agents -> geno-agents (variant: exp-1)

# Now in THIS cwd:
#   /gt-agents            → exp-1's SKILL.md
#   /geno-agents          → main's SKILL.md (global, unaffected)
# In OTHER cwds:
#   /gt-agents            → main (through active)
#   /geno-agents          → main (global)
\`\`\`

## New file: \`genotools/bootstrap.py\`

Contains:
- \`gt-bootstrap.sh\` script body (shell, ~30 lines)
- \`ensure_hook_registered()\` / \`remove_hook()\` — manage settings.json
- \`materialize_cwd_aliases()\` — Python equivalent of the shell script
- \`remove_cwd_aliases()\` — cleanup per-skillset

## Test plan

- [x] \`install\` registers hook in settings.json alongside existing hooks
- [x] \`install --here\` creates gt-* symlinks in cwd
- [x] Aliases go through \`active\` (verified symlink target)
- [x] \`fork\` + \`use --here\` → cwd alias points directly to variant worktree
- [x] Marker in variant's SKILL.md visible via cwd alias, not via global
- [x] \`use --here agents@main\` restores cwd to main
- [x] \`remove\` cleans cwd aliases + hook entry when last skillset removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)