### PR TITLE
Standardize nomenclature: {skillset}-{sub-skillset}-{skill-slug}

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,35 +79,74 @@ On failure at any step, the partially created directory is cleaned up.
 
 Uninstall enumerates skills (root SKILL.md + `skills/*/SKILL.md`) and calls `npx skills remove`.
 
+## Nomenclature
+
+Skills follow a strict naming hierarchy: `{skillset}-{sub-skillset}-{skill-slug}`.
+
+- **Skillset** = a geno-ecosystem repo (e.g., `geno-tools`, `geno-kaggle`)
+- **Sub-skillset** = pluralized noun grouping, ALWAYS required (e.g., `repos`, `icons`, `tasks`)
+- **Skill slug** = action verb (e.g., `scaffold`, `generate`, `start`)
+- **Umbrella skill** = just the skillset name (e.g., `geno-tools`)
+
+See `docs/skillsets/nomenclature.md` for the full spec and cross-ecosystem migration reference.
+
 ## Plugin structure (this repo)
 
 ```
 geno-tools/
-├── .claude-plugin/plugin.json   # Claude Code plugin manifest
-├── skills/geno-tools/SKILL.md   # umbrella skill describing the meta-CLI
-├── commands/                    # slash commands wrapping the CLI
+├── .claude-plugin/plugin.json               # Claude Code plugin manifest
+├── skills/geno-tools/SKILL.md               # umbrella skill
+├── skills/geno-tools-repos-scaffold/SKILL.md  # repo scaffolding skill
+├── skills/geno-tools-icons-generate/SKILL.md  # icon generation skill
+├── commands/                                # slash commands wrapping the CLI
 │   ├── gt-install.md
 │   ├── gt-remove.md
 │   ├── gt-ls.md
-│   └── gt-update.md
-├── genotools/                   # Python CLI package
-│   ├── cli.py                   # argparse, subcommand routing
-│   ├── commands.py              # install/remove implemented, rest are stubs
-│   ├── paths.py                 # on-disk layout utilities
-│   └── registry.py              # curated registry of known skillsets
-└── pyproject.toml               # pip/pipx entry point
+│   ├── gt-update.md
+│   └── gt-repos-scaffold.md
+├── genotools/                               # Python CLI package
+│   ├── cli.py                               # argparse, subcommand routing
+│   ├── commands.py                          # install/remove implemented, rest are stubs
+│   ├── paths.py                             # on-disk layout utilities
+│   └── registry.py                          # curated registry of known skillsets
+└── pyproject.toml                           # pip/pipx entry point
 ```
 
 ## What a skillset repo needs to provide
 
-Minimum viable `geno-{name}` skillset:
+Every geno-ecosystem repo must have:
+
+| File | Purpose |
+|------|---------|
+| `CLAUDE.md` | Project instructions for agents, including compliance rules |
+| `package.json` | Skills manifest with name, version, skills map |
+| `.geno-agents` | Agent identity: role, description, capabilities |
+| `skills/geno-{name}/SKILL.md` | Umbrella skill with YAML frontmatter |
+| `README.md` | Human-facing docs: install, commands table, repo tree |
+
+Minimum file structure:
 
 ```
 geno-{name}/
+├── CLAUDE.md               # compliance rules + project context
 ├── SKILL.md                # umbrella skill manifest
+├── skills/
+│   └── geno-{name}-{sub-skillset}-{skill}/
+│       └── SKILL.md        # sub-skill (follows nomenclature)
 ├── commands/
 │   └── gt-{name}-*.md      # slash commands (any *.md works)
 └── pyproject.toml           # optional — triggers venv creation if present
 ```
 
 Skillsets use the skills format (not the plugin format). Only geno-tools itself ships as a Claude Code plugin.
+
+### CLAUDE.md compliance section
+
+Every repo's CLAUDE.md must include a Compliance section covering:
+
+1. **Nomenclature** — skill naming rules with repo-specific examples
+2. **Repo structure** — required files table
+3. **SKILL.md frontmatter** — template showing required fields
+4. **Adding a new skill** — checklist of files to update
+
+See `geno-dev/CLAUDE.md` as the reference implementation.

--- a/commands/gt-repos-scaffold.md
+++ b/commands/gt-repos-scaffold.md
@@ -1,0 +1,19 @@
+---
+name: gt-repos-scaffold
+description: Scaffold a new geno-ecosystem repository with all required conventions
+argument-hint: "<name> [--description 'short description'] [--python] [--docker]"
+---
+
+# Scaffold New Geno Repo
+
+Create a new `geno-{name}` repository following ecosystem conventions.
+
+## Input
+
+`$ARGUMENTS` — the short name for the new repo (e.g. `foo` creates `geno-foo`).
+
+If `$ARGUMENTS` is empty, ask the user for the name and description.
+
+## Execution
+
+Invoke the `geno-tools-repos-scaffold` skill to scaffold the repository. The skill handles all file generation, git init, and reporting.

--- a/docs/skillsets/creating.md
+++ b/docs/skillsets/creating.md
@@ -82,7 +82,11 @@ Copy-once files into `~/.geno-tools/geno-{name}/configs/`. Only created if missi
 
 ## SKILL.md
 
-The umbrella manifest that describes your skillset to the agent. Use YAML frontmatter:
+The umbrella manifest that describes your skillset to the agent. Use YAML frontmatter.
+
+!!! tip "Naming convention"
+    All skill names must follow the `{skillset}-{sub-skillset}-{skill-slug}` pattern.
+    Sub-skillsets are always pluralized nouns. See the [Nomenclature](nomenclature.md) spec for details.
 
 ```markdown
 ---

--- a/docs/skillsets/nomenclature.md
+++ b/docs/skillsets/nomenclature.md
@@ -1,0 +1,115 @@
+# Nomenclature
+
+Naming standard for skills across the geno-ecosystem.
+
+## Hierarchy
+
+| Term | Definition | Example |
+|------|-----------|---------|
+| **Skillset** | A geno-ecosystem repo | `geno-tools`, `geno-kaggle` |
+| **Sub-skillset** | Logical grouping within a skillset | `repos`, `icons`, `benchmarks` |
+| **Skill** | Individual capability within a sub-skillset | `scaffold`, `generate`, `run` |
+
+## Naming pattern
+
+```
+{skillset}-{sub-skillset}-{skill-slug}
+```
+
+### Rules
+
+1. **Skillset** = the repo name (`geno-tools`, `geno-dev`, `geno-kaggle`, etc.)
+2. **Sub-skillset** = always a **pluralized noun** (`repos` not `repo`, `tasks` not `task`, `benchmarks` not `benchmark`)
+3. **Skill slug** = action verb (`scaffold`, `generate`, `start`, `rewrite`, `run`, `scrape`)
+4. **Sub-skillset is always required** — even when a repo has only one skill per group
+5. **Umbrella skill** = just `{skillset}` (e.g., `geno-tools`). Every repo has exactly one.
+
+### `gt-` slash command aliases
+
+The `gt-` prefix is a secondary aliasing convention for slash commands. It is not part of the canonical skill name.
+
+| Skill type | `gt-` alias pattern |
+|-----------|---------------------|
+| geno-tools' own skills | `/gt-{sub-skillset}-{skill}` |
+| Other skillsets | `/gt-{short-name}-{sub-skillset}-{skill}` |
+
+Examples:
+
+| Canonical skill name | Slash command |
+|---------------------|---------------|
+| `geno-tools-repos-scaffold` | `/gt-repos-scaffold` |
+| `geno-tools-icons-generate` | `/gt-icons-generate` |
+| `geno-dev-tasks-start` | `/gt-dev-tasks-start` |
+| `geno-kaggle-benchmarks-run` | `/gt-kaggle-benchmarks-run` |
+
+## Compliant examples
+
+### geno-tools
+
+| Skill name | Sub-skillset | Skill | Notes |
+|-----------|-------------|-------|-------|
+| `geno-tools` | — | — | umbrella |
+| `geno-tools-repos-scaffold` | repos | scaffold | create new geno-* repos |
+| `geno-tools-icons-generate` | icons | generate | pixel art icon generation |
+
+### geno-dev (compliant)
+
+| Skill name | Sub-skillset | Skill | Notes |
+|-----------|-------------|-------|-------|
+| `geno-dev` | — | — | umbrella |
+| `geno-dev-tasks-start` | tasks | start | pick up and execute a task |
+| `geno-dev-commits-rewrite` | commits | rewrite | clean up git history |
+
+## Cross-ecosystem migration reference
+
+Current names → compliant names for remaining repos. These are targets for future migration, not immediate changes.
+
+### geno-agents
+
+| Current | Compliant |
+|---------|-----------|
+| `geno-agents-tasks-start` | ✓ already compliant |
+| `geno-agents-supercharge` | `geno-agents-loops-supercharge` |
+
+### geno-kaggle
+
+| Current | Compliant |
+|---------|-----------|
+| `geno-create-benchmark-kaggle` | `geno-kaggle-benchmarks-create` |
+| `geno-run-kaggle-bench` | `geno-kaggle-benchmarks-run` |
+| `geno-upload-kaggle` | `geno-kaggle-notebooks-upload` |
+| `geno-kaggle-discussion` | `geno-kaggle-discussions-scrape` |
+| `geno-kaggle-benchmarks-task-generate` | `geno-kaggle-benchmarks-generate` |
+| `geno-kaggle-benchmarks-task-review` | `geno-kaggle-benchmarks-review` |
+
+### geno-taxes
+
+| Current | Compliant |
+|---------|-----------|
+| `geno-tax-status` | `geno-taxes-filings-status` |
+| `geno-tax-parse` | `geno-taxes-documents-parse` |
+| `geno-tax-summary` | `geno-taxes-filings-summarize` |
+| `geno-tax-checklist` | `geno-taxes-documents-checklist` |
+| `geno-tax-fetch` | `geno-taxes-documents-fetch` |
+
+### geno-media
+
+| Current | Compliant |
+|---------|-----------|
+| `geno-media-audiobook-create` | `geno-media-audiobooks-create` |
+| `geno-media-audiobook-recursive` | `geno-media-audiobooks-recursive` |
+| `geno-media-video-create` | `geno-media-videos-create` |
+| `geno-media-podcast-create` | `geno-media-podcasts-create` |
+| `geno-media-audio-upload` | `geno-media-uploads-audio` |
+| `geno-media-tts-config` | `geno-media-configs-tts` |
+| `geno-media-stt-config` | `geno-media-configs-stt` |
+
+### geno-research
+
+| Current | Compliant |
+|---------|-----------|
+| `geno-research-paper-generate` | `geno-research-papers-generate` |
+| `geno-research-repo-docs` | `geno-research-docs-generate` |
+| `geno-research-deep` | `geno-research-topics-deep` |
+| `geno-research-notes` | `geno-research-notes-manage` |
+| `geno-research-supercharge` | `geno-research-loops-supercharge` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
   - Skillsets:
       - skillsets/index.md
       - Creating a Skillset: skillsets/creating.md
+      - Nomenclature: skillsets/nomenclature.md
   - Architecture:
       - architecture/index.md
       - Disk Layout: architecture/layout.md

--- a/skills/geno-tools-icons-generate/SKILL.md
+++ b/skills/geno-tools-icons-generate/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: geno-icons
+name: geno-tools-icons-generate
 description: >-
   Generate pixel art icons for geno-ecosystem projects using SD 1.5 + pixel art LoRA.
-  Use when user says /gt-icons, /gt-icons-generate, or wants to create/regenerate/refine
+  Use when user says /gt-icons-generate or wants to create/regenerate/refine
   pixel art icons for geno-* repos.
 argument-hint: "[generate|refine|status] [project-name] [--seeds N] [--prompts 'custom prompt']"
 license: MIT
@@ -11,7 +11,7 @@ metadata:
   version: "0.1.0"
 ---
 
-# geno-icons — Pixel Art Icon Generator
+# geno-tools-icons-generate — Pixel Art Icon Generator
 
 Generate 8-bit pixel art icons for geno-ecosystem projects using Stable Diffusion 1.5 with a pixel art LoRA, running locally on MPS (Apple Silicon).
 
@@ -39,7 +39,7 @@ torch torchvision diffusers transformers accelerate safetensors Pillow peft
 
 Parse the user's arguments to determine the action:
 
-### `/gt-icons generate [project-name]` or `/gt-icons`
+### `/gt-icons-generate [project-name]`
 
 Generate pixel art icon variants for one or all geno-ecosystem projects.
 
@@ -175,7 +175,7 @@ for project, base_prompts in projects.items():
 | obsidian-geno-claude | obsidian crystal + AI glow, dark gem + brain, hexagonal stone, magic orb, crystal shard |
 | obsidian-genovox | crystal + sound waves, speaking stone, gem microphone, voice waveform in crystal |
 
-### `/gt-icons refine <project-name> [--prompts 'custom prompt']`
+### `/gt-icons-generate refine <project-name> [--prompts 'custom prompt']`
 
 Regenerate icons for a single project with custom or adjusted prompts.
 
@@ -184,7 +184,7 @@ Regenerate icons for a single project with custom or adjusted prompts.
 3. Generate a new batch (use seed range 200+ to avoid collisions with prior runs)
 4. Open results and let the user pick
 
-### `/gt-icons status`
+### `/gt-icons-generate status`
 
 Show which projects have icons and which don't:
 ```bash
@@ -199,7 +199,7 @@ for repo in "$REPOS_DIR"/geno-* "$REPOS_DIR"/obsidian-*; do
 done
 ```
 
-### `/gt-icons animate <project-name>`
+### `/gt-icons-generate animate <project-name>`
 
 Generate an animated GIF from the selected icon using AnimateDiff.
 

--- a/skills/geno-tools-repos-scaffold/SKILL.md
+++ b/skills/geno-tools-repos-scaffold/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: geno-tools-repos-scaffold
+description: >-
+  Scaffold a new geno-ecosystem repository with all required files and conventions.
+  Use when user says /gt-repos-scaffold or wants to create a new geno-* project.
+argument-hint: "<name> [--description 'short description'] [--python] [--docker]"
+license: MIT
+metadata:
+  author: 42euge
+  version: "0.1.0"
+---
+
+# Scaffold New Geno Repo
+
+Create a new `geno-{name}` repository in the geno-ecosystem with all required files following ecosystem conventions.
+
+## Input
+
+`$ARGUMENTS` should include:
+- **name** (required) — the short name (e.g. `foo` creates `geno-foo`)
+- **--description** — one-line description (prompted if omitted)
+- **--python** — include Python CLI scaffolding (`pyproject.toml`, `geno_name/cli.py`)
+- **--docker** — include Dockerfile scaffolding
+
+If `$ARGUMENTS` is empty, ask the user for the name and description.
+
+## Ecosystem conventions
+
+Every geno-* repo MUST have:
+
+| File | Purpose |
+|---|---|
+| `CLAUDE.md` | Project instructions for agents, including compliance rules |
+| `README.md` | Install instructions, commands table, repo structure, MIT license |
+| `LICENSE` | MIT License, Copyright (c) 2025 Eugenio Ruiz |
+| `.gitignore` | Standard Python/Node patterns + `.DS_Store` |
+| `.geno-agents` | YAML: role, description, capabilities list |
+| `package.json` | Vercel Skills manifest with name, version, description, skills map, repository |
+| `skills/geno-{name}/SKILL.md` | Umbrella skill with YAML frontmatter (name, description, license, metadata) |
+
+Skill names follow the nomenclature: `geno-{name}-{sub-skillset}-{skill-slug}` where sub-skillset is a pluralized noun. See https://42euge.github.io/geno-tools/skillsets/nomenclature/
+
+## Workflow
+
+### 1. Gather info
+
+Determine from `$ARGUMENTS` or by asking:
+- **name** — short kebab-case name (no `geno-` prefix, that gets added)
+- **description** — one-line description
+- **type** — pure markdown (default), python CLI, or docker-based
+
+### 2. Create the repo directory
+
+The ecosystem repos live at:
+```
+~/Library/Mobile Documents/iCloud~md~obsidian/Documents/Everything/research/kaggle/gemma-4-good-hackathon/geno-ecosystem/repos/
+```
+
+Create `geno-{name}/` there. If it already exists, stop and tell the user.
+
+### 3. Generate files
+
+#### Always generated
+
+**CLAUDE.md:**
+```markdown
+# geno-{name} — {description} skillset
+
+{description} for Claude Code.
+
+## Skills
+
+| Skill name | Sub-skillset | Skill | Slash command |
+|-----------|-------------|-------|---------------|
+| `geno-{name}` | — | — | — (umbrella) |
+
+## Compliance
+
+This repo follows geno-ecosystem conventions. All contributors and agents must adhere to:
+
+### Nomenclature
+
+Skill names follow: `{skillset}-{sub-skillset}-{skill-slug}`
+
+- **Skillset** = this repo's name: `geno-{name}`
+- **Sub-skillset** = always a **pluralized noun**
+- **Skill slug** = action verb
+- **Umbrella** = just `geno-{name}`
+
+Full spec: https://42euge.github.io/geno-tools/skillsets/nomenclature/
+
+### Adding a new skill
+
+1. Create `skills/geno-{name}-{sub-skillset}-{skill}/SKILL.md` with compliant frontmatter
+2. Update the umbrella `skills/geno-{name}/SKILL.md`
+3. Update `README.md` — command table and repo tree
+4. Update this file's Skills table
+```
+
+**README.md:**
+```markdown
+# geno-{name}
+
+{description} for [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
+
+## Install
+
+\```bash
+npx skills add 42euge/geno-{name}
+\```
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `/gt-{name}` | {description} |
+
+## Repository structure
+
+\```
+geno-{name}/
+├── package.json
+├── .geno-agents
+└── skills/
+    └── geno-{name}/
+        └── SKILL.md
+\```
+
+## Runtime
+
+{runtime description}
+
+## License
+
+MIT
+```
+
+**LICENSE:** MIT License, Copyright (c) 2025 Eugenio Ruiz (use the standard text from other geno-* repos)
+
+**.gitignore:**
+```
+.DS_Store
+__pycache__/
+*.pyc
+*.py[cod]
+*.egg-info/
+dist/
+build/
+.venv/
+.env
+.idea/
+.vscode/
+```
+
+**.geno-agents:**
+```yaml
+role: geno-{name}
+description: {description}
+capabilities:
+  - {derive 2-3 capability keywords from the description}
+```
+
+**package.json:**
+```json
+{
+  "name": "geno-{name}",
+  "version": "0.1.0",
+  "description": "{description}",
+  "skills": {
+    "geno-{name}": "skills/geno-{name}"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/42euge/geno-{name}"
+  }
+}
+```
+
+**skills/geno-{name}/SKILL.md:**
+```markdown
+---
+name: geno-{name}
+description: >-
+  {description}.
+  Use when user says /gt-{name}.
+license: MIT
+metadata:
+  author: 42euge
+  version: "0.1.0"
+---
+
+# geno-{name}
+
+{description}.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `/gt-{name}` | {description} |
+
+## Runtime
+
+{runtime description}
+```
+
+#### If --python flag
+
+Add:
+
+**pyproject.toml:**
+```toml
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "geno-{name}"
+version = "0.1.0"
+description = "{description}"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.scripts]
+geno-{name} = "geno_{name_underscored}.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["geno_{name_underscored}*"]
+```
+
+**geno_{name_underscored}/__init__.py:** empty file
+
+**geno_{name_underscored}/cli.py:**
+```python
+import argparse
+
+def main():
+    parser = argparse.ArgumentParser(description="{description}")
+    parser.parse_args()
+
+if __name__ == "__main__":
+    main()
+```
+
+#### If --docker flag
+
+Add a minimal **Dockerfile** and **build.sh** / **run.sh** scripts.
+
+### 4. Initialize git
+
+```bash
+cd geno-{name}
+git init
+git add -A
+git commit -m "Initial scaffold for geno-{name}"
+```
+
+### 5. Report
+
+Tell the user:
+- Where the repo was created
+- What files were generated
+- Next steps: add skills, commands, or a Python CLI
+- How to install it: `geno-tools install /path/to/geno-{name}`

--- a/skills/geno-tools/SKILL.md
+++ b/skills/geno-tools/SKILL.md
@@ -2,8 +2,8 @@
 name: geno-tools
 description: >-
   Meta-CLI for installing and managing geno-* skillsets.
-  Use when user says /gt-install, /gt-remove, /gt-ls, /gt-update,
-  or asks about installing/removing/listing geno ecosystem skillsets.
+  Use when user says /gt-install, /gt-remove, /gt-ls, /gt-update, /gt-repos-scaffold,
+  /gt-icons-generate, or asks about installing/removing/listing/creating geno ecosystem skillsets.
 allowed-tools: "Bash(geno-tools *) Bash(python3 -m genotools *)"
 ---
 
@@ -25,6 +25,7 @@ which geno-tools >/dev/null 2>&1 || echo "geno-tools CLI not on PATH. Install: p
 | taxes | Tax document parsing, CPA packet prep |
 | kaggle | Kaggle benchmarks, competition notebooks, discussion scraping |
 | dev | Developer utilities, Colab uploads, commit rewriting |
+| iso | Isolated Docker containers for running Claude Code |
 
 ## Commands
 


### PR DESCRIPTION
## Summary
Stacked on #13.

- Define naming hierarchy: **skillset** (repo) > **sub-skillset** (pluralized noun) > **skill** (action verb)
- Rename geno-tools' own skills to comply: `geno-new-repo` → `geno-tools-repos-scaffold`, `geno-icons` → `geno-tools-icons-generate`
- Add nomenclature spec at `docs/skillsets/nomenclature.md` with cross-ecosystem migration reference
- Require `CLAUDE.md` with compliance section in every geno-* repo
- Update scaffold template to generate compliant repos

## Test plan
- [ ] `ls skills/` shows `geno-tools/`, `geno-tools-repos-scaffold/`, `geno-tools-icons-generate/`
- [ ] `grep -r "geno-new-repo\|geno-icons" skills/ commands/ CLAUDE.md` returns no hits
- [ ] Nomenclature page renders in mkdocs

🤖 Generated with [Claude Code](https://claude.com/claude-code)