### PR TITLE
Remove gt- prefix: use canonical geno-* names everywhere

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ## Dual installation
 
-- **Claude Code plugin**: `.claude-plugin/plugin.json` + `skills/` + `commands/` expose `/gt-install`, `/gt-remove`, `/gt-ls`, `/gt-update` slash commands
+- **Claude Code plugin**: `.claude-plugin/plugin.json` + `skills/` + `commands/` expose `/geno-tools-install`, `/geno-tools-remove`, `/geno-tools-ls`, `/geno-tools-update` slash commands
 - **Python CLI**: `pyproject.toml` → `geno-tools` binary on PATH via pipx/pip
 
 The plugin wraps the CLI — both require the Python package installed.
@@ -23,10 +23,10 @@ geno-tools = "genotools.cli:main"
 
 | Command | Slash command | Status |
 |---------|---------------|--------|
-| `geno-tools ls [--available]` | `/gt-ls` | implemented |
-| `geno-tools install <name\|url\|path> [--here]` | `/gt-install` | implemented |
-| `geno-tools remove <name> [--keep-data]` | `/gt-remove` | implemented |
-| `geno-tools update [name]` | `/gt-update` | stub |
+| `geno-tools ls [--available]` | `/geno-tools-ls` | implemented |
+| `geno-tools install <name\|url\|path> [--here]` | `/geno-tools-install` | implemented |
+| `geno-tools remove <name> [--keep-data]` | `/geno-tools-remove` | implemented |
+| `geno-tools update [name]` | `/geno-tools-update` | stub |
 | `geno-tools dev <name> <path>` | — | stub |
 | `geno-tools fork <name> <variant> [--isolated-venv]` | — | stub |
 | `geno-tools use <name>@<variant> [--here]` | — | stub |
@@ -99,11 +99,11 @@ geno-tools/
 ├── skills/geno-tools-repos-scaffold/SKILL.md  # repo scaffolding skill
 ├── skills/geno-tools-icons-generate/SKILL.md  # icon generation skill
 ├── commands/                                # slash commands wrapping the CLI
-│   ├── gt-install.md
-│   ├── gt-remove.md
-│   ├── gt-ls.md
-│   ├── gt-update.md
-│   └── gt-repos-scaffold.md
+│   ├── geno-tools-install.md
+│   ├── geno-tools-remove.md
+│   ├── geno-tools-ls.md
+│   ├── geno-tools-update.md
+│   └── geno-tools-repos-scaffold.md
 ├── genotools/                               # Python CLI package
 │   ├── cli.py                               # argparse, subcommand routing
 │   ├── commands.py                          # install/remove implemented, rest are stubs
@@ -134,7 +134,7 @@ geno-{name}/
 │   └── geno-{name}-{sub-skillset}-{skill}/
 │       └── SKILL.md        # sub-skill (follows nomenclature)
 ├── commands/
-│   └── gt-{name}-*.md      # slash commands (any *.md works)
+│   └── geno-{name}-*.md    # slash commands (any *.md works)
 └── pyproject.toml           # optional — triggers venv creation if present
 ```
 

--- a/commands/geno-tools-install.md
+++ b/commands/geno-tools-install.md
@@ -1,5 +1,5 @@
 ---
-name: gt-install
+name: geno-tools-install
 description: Install a geno ecosystem skillset from registry, path, or git URL
 allowed-tools: "Bash(geno-tools install *) Bash(python3 -m genotools install *)"
 argument-hint: "<name|url|path>  e.g. 'media', 'kaggle', 'https://github.com/user/geno-foo.git'"

--- a/commands/geno-tools-ls.md
+++ b/commands/geno-tools-ls.md
@@ -1,5 +1,5 @@
 ---
-name: gt-ls
+name: geno-tools-ls
 description: List installed geno ecosystem skillsets or show the available registry
 allowed-tools: "Bash(geno-tools ls *) Bash(python3 -m genotools ls *)"
 argument-hint: "[--available]"

--- a/commands/geno-tools-remove.md
+++ b/commands/geno-tools-remove.md
@@ -1,5 +1,5 @@
 ---
-name: gt-remove
+name: geno-tools-remove
 description: Uninstall a geno ecosystem skillset
 allowed-tools: "Bash(geno-tools remove *) Bash(python3 -m genotools remove *)"
 argument-hint: "<name> [--keep-data]"

--- a/commands/geno-tools-repos-scaffold.md
+++ b/commands/geno-tools-repos-scaffold.md
@@ -1,5 +1,5 @@
 ---
-name: gt-repos-scaffold
+name: geno-tools-repos-scaffold
 description: Scaffold a new geno-ecosystem repository with all required conventions
 argument-hint: "<name> [--description 'short description'] [--python] [--docker]"
 ---

--- a/commands/geno-tools-update.md
+++ b/commands/geno-tools-update.md
@@ -1,5 +1,5 @@
 ---
-name: gt-update
+name: geno-tools-update
 description: Update geno ecosystem skillsets to their latest version
 allowed-tools: "Bash(geno-tools update *) Bash(python3 -m genotools update *)"
 argument-hint: "[name]  omit to update all"

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -6,7 +6,7 @@ geno-tools is structured around a few core concepts:
 
 geno-tools itself can be installed two ways:
 
-- **Claude Code plugin** — `claude /plugin install 42euge/geno-tools` adds slash commands (`/gt-install`, `/gt-ls`, etc.) inside Claude Code
+- **Claude Code plugin** — `claude /plugin install 42euge/geno-tools` adds slash commands (`/geno-tools-install`, `/geno-tools-ls`, etc.) inside Claude Code
 - **Python CLI** — `pipx install git+https://github.com/42euge/geno-tools` puts the `geno-tools` binary on your PATH
 
 The plugin wraps the CLI, so both paths require the Python package. The ecosystem skillsets geno-tools installs remain skills-based (registered via `npx skills add`).
@@ -54,10 +54,10 @@ geno-tools/
 ├── .claude-plugin/plugin.json   # Claude Code plugin manifest
 ├── skills/geno-tools/SKILL.md   # umbrella skill describing the meta-CLI
 ├── commands/                    # slash commands wrapping the CLI
-│   ├── gt-install.md
-│   ├── gt-remove.md
-│   ├── gt-ls.md
-│   └── gt-update.md
+│   ├── geno-tools-install.md
+│   ├── geno-tools-remove.md
+│   ├── geno-tools-ls.md
+│   └── geno-tools-update.md
 ├── genotools/                   # Python CLI package
 │   ├── cli.py
 │   ├── commands.py

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2,11 +2,11 @@
 
 All commands are invoked as `geno-tools <command> [options]`.
 
-If geno-tools is installed as a Claude Code plugin, the core commands are also available as slash commands: `/gt-install`, `/gt-remove`, `/gt-ls`, `/gt-update`.
+If geno-tools is installed as a Claude Code plugin, the core commands are also available as slash commands: `/geno-tools-install`, `/geno-tools-remove`, `/geno-tools-ls`, `/geno-tools-update`.
 
 ## `ls`
 
-List installed skillsets or the available registry. Slash command: `/gt-ls`.
+List installed skillsets or the available registry. Slash command: `/geno-tools-ls`.
 
 ```bash
 geno-tools ls                # installed skillsets + active variant
@@ -23,7 +23,7 @@ geno-tools ls --available    # curated registry
 
 ## `install`
 
-Install a skillset from the registry, a git URL, or a local path. Slash command: `/gt-install`.
+Install a skillset from the registry, a git URL, or a local path. Slash command: `/geno-tools-install`.
 
 ```bash
 geno-tools install media
@@ -130,7 +130,7 @@ geno-tools promote media exp-1
 
 ## `update`
 
-Pull latest changes on the main worktree. Slash command: `/gt-update`.
+Pull latest changes on the main worktree. Slash command: `/geno-tools-update`.
 
 ```bash
 geno-tools update media    # update one
@@ -149,7 +149,7 @@ Skips skillsets in `dev` mode (the source is already live).
 
 ## `remove`
 
-Uninstall a skillset. Replays the install in reverse — deterministic, no orphaned files. Slash command: `/gt-remove`.
+Uninstall a skillset. Replays the install in reverse — deterministic, no orphaned files. Slash command: `/geno-tools-remove`.
 
 ```bash
 geno-tools remove media

--- a/docs/docs-home.md
+++ b/docs/docs-home.md
@@ -66,8 +66,8 @@ Fork a skillset, experiment in isolation, promote back to main. Git worktrees un
     claude /plugin install 42euge/geno-tools
     pipx install git+https://github.com/42euge/geno-tools
 
-    /gt-ls --available               # see the registry
-    /gt-install media                # install geno-media
+    /geno-tools-ls --available               # see the registry
+    /geno-tools-install media                # install geno-media
     geno-tools fork media exp-1      # branch a variant
     geno-tools use media@exp-1       # activate it
     geno-tools promote media exp-1   # merge back to main

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,7 +16,7 @@ geno-tools can be installed as a **Claude Code plugin** or as a **standalone CLI
 claude /plugin install 42euge/geno-tools
 ```
 
-This gives you `/gt-install`, `/gt-remove`, `/gt-ls`, and `/gt-update` slash commands inside Claude Code. The plugin wraps the CLI, so you still need the CLI on your PATH for the slash commands to work:
+This gives you `/geno-tools-install`, `/geno-tools-remove`, `/geno-tools-ls`, and `/geno-tools-update` slash commands inside Claude Code. The plugin wraps the CLI, so you still need the CLI on your PATH for the slash commands to work:
 
 ```bash
 pipx install git+https://github.com/42euge/geno-tools

--- a/docs/skillsets/creating.md
+++ b/docs/skillsets/creating.md
@@ -9,7 +9,7 @@ geno-myskill/
 ├── genotools.yaml      # required — the manifest
 ├── SKILL.md            # umbrella description for the agent
 └── commands/
-    └── gt-myskill.md   # at least one slash command
+    └── geno-myskill.md   # at least one slash command
 ```
 
 ## The manifest — `genotools.yaml`
@@ -93,7 +93,7 @@ The umbrella manifest that describes your skillset to the agent. Use YAML frontm
 name: geno-myskill
 description: >-
   What this skillset does and when to use it.
-  Use when user says /gt-myskill.
+  Use when user says /geno-myskill.
 license: MIT
 metadata:
   author: your-username
@@ -107,7 +107,7 @@ Description, install instructions, command table, runtime notes.
 
 ## Slash commands
 
-Each `.md` file in `commands/` becomes a `/gt-*` slash command. The filename (minus `.md`) is the command name.
+Each `.md` file in `commands/` becomes a slash command. The filename (minus `.md`) is the command name.
 
 Write these as instructions for the agent — what to do when the user invokes the command, what tools to use, what output to produce.
 
@@ -137,4 +137,4 @@ _REGISTRY: dict[str, str] = {
 ```
 
 !!! note "Skillsets vs. plugins"
-    Ecosystem skillsets use the skills format (`SKILL.md` + `commands/*.md`) and are installed via `geno-tools install`. Only geno-tools itself ships as a Claude Code plugin (`.claude-plugin/plugin.json`) to provide the `/gt-install`, `/gt-remove`, `/gt-ls`, and `/gt-update` slash commands.
+    Ecosystem skillsets use the skills format (`SKILL.md` + `commands/*.md`) and are installed via `geno-tools install`. Only geno-tools itself ships as a Claude Code plugin (`.claude-plugin/plugin.json`) to provide the `/geno-tools-install`, `/geno-tools-remove`, `/geno-tools-ls`, and `/geno-tools-update` slash commands.

--- a/docs/skillsets/index.md
+++ b/docs/skillsets/index.md
@@ -26,7 +26,7 @@ geno-tools install research
 
 When you install a skillset, you get:
 
-- **Slash commands** — markdown files that appear as `/gt-*` commands in your coding agent
+- **Slash commands** — markdown files that appear as `/geno-*` commands in your coding agent
 - **SKILL.md** — an umbrella manifest describing the skillset's capabilities
 - **Runtime scripts** (optional) — Python/shell scripts symlinked for command use
 - **Config defaults** (optional) — copy-once configs that preserve user edits across updates

--- a/docs/skillsets/nomenclature.md
+++ b/docs/skillsets/nomenclature.md
@@ -24,23 +24,16 @@ Naming standard for skills across the geno-ecosystem.
 4. **Sub-skillset is always required** — even when a repo has only one skill per group
 5. **Umbrella skill** = just `{skillset}` (e.g., `geno-tools`). Every repo has exactly one.
 
-### `gt-` slash command aliases
+### Slash commands
 
-The `gt-` prefix is a secondary aliasing convention for slash commands. It is not part of the canonical skill name.
+Slash commands use the canonical skill name directly. The command filename in `commands/` must match the skill name:
 
-| Skill type | `gt-` alias pattern |
-|-----------|---------------------|
-| geno-tools' own skills | `/gt-{sub-skillset}-{skill}` |
-| Other skillsets | `/gt-{short-name}-{sub-skillset}-{skill}` |
-
-Examples:
-
-| Canonical skill name | Slash command |
-|---------------------|---------------|
-| `geno-tools-repos-scaffold` | `/gt-repos-scaffold` |
-| `geno-tools-icons-generate` | `/gt-icons-generate` |
-| `geno-dev-tasks-start` | `/gt-dev-tasks-start` |
-| `geno-kaggle-benchmarks-run` | `/gt-kaggle-benchmarks-run` |
+| Canonical skill name | Slash command | Command file |
+|---------------------|---------------|-------------|
+| `geno-tools-repos-scaffold` | `/geno-tools-repos-scaffold` | `geno-tools-repos-scaffold.md` |
+| `geno-tools-icons-generate` | `/geno-tools-icons-generate` | — (skill only) |
+| `geno-dev-tasks-start` | `/geno-dev-tasks-start` | — (skill only) |
+| `geno-kaggle-benchmarks-run` | `/geno-kaggle-benchmarks-run` | — (skill only) |
 
 ## Compliant examples
 

--- a/skills/geno-tools-icons-generate/SKILL.md
+++ b/skills/geno-tools-icons-generate/SKILL.md
@@ -2,7 +2,7 @@
 name: geno-tools-icons-generate
 description: >-
   Generate pixel art icons for geno-ecosystem projects using SD 1.5 + pixel art LoRA.
-  Use when user says /gt-icons-generate or wants to create/regenerate/refine
+  Use when user says /geno-tools-icons-generate or wants to create/regenerate/refine
   pixel art icons for geno-* repos.
 argument-hint: "[generate|refine|status] [project-name] [--seeds N] [--prompts 'custom prompt']"
 license: MIT
@@ -39,7 +39,7 @@ torch torchvision diffusers transformers accelerate safetensors Pillow peft
 
 Parse the user's arguments to determine the action:
 
-### `/gt-icons-generate [project-name]`
+### `/geno-tools-icons-generate [project-name]`
 
 Generate pixel art icon variants for one or all geno-ecosystem projects.
 
@@ -175,7 +175,7 @@ for project, base_prompts in projects.items():
 | obsidian-geno-claude | obsidian crystal + AI glow, dark gem + brain, hexagonal stone, magic orb, crystal shard |
 | obsidian-genovox | crystal + sound waves, speaking stone, gem microphone, voice waveform in crystal |
 
-### `/gt-icons-generate refine <project-name> [--prompts 'custom prompt']`
+### `/geno-tools-icons-generate refine <project-name> [--prompts 'custom prompt']`
 
 Regenerate icons for a single project with custom or adjusted prompts.
 
@@ -184,7 +184,7 @@ Regenerate icons for a single project with custom or adjusted prompts.
 3. Generate a new batch (use seed range 200+ to avoid collisions with prior runs)
 4. Open results and let the user pick
 
-### `/gt-icons-generate status`
+### `/geno-tools-icons-generate status`
 
 Show which projects have icons and which don't:
 ```bash
@@ -199,7 +199,7 @@ for repo in "$REPOS_DIR"/geno-* "$REPOS_DIR"/obsidian-*; do
 done
 ```
 
-### `/gt-icons-generate animate <project-name>`
+### `/geno-tools-icons-generate animate <project-name>`
 
 Generate an animated GIF from the selected icon using AnimateDiff.
 

--- a/skills/geno-tools-repos-scaffold/SKILL.md
+++ b/skills/geno-tools-repos-scaffold/SKILL.md
@@ -2,7 +2,7 @@
 name: geno-tools-repos-scaffold
 description: >-
   Scaffold a new geno-ecosystem repository with all required files and conventions.
-  Use when user says /gt-repos-scaffold or wants to create a new geno-* project.
+  Use when user says /geno-tools-repos-scaffold or wants to create a new geno-* project.
 argument-hint: "<name> [--description 'short description'] [--python] [--docker]"
 license: MIT
 metadata:
@@ -113,7 +113,7 @@ npx skills add 42euge/geno-{name}
 
 | Command | Description |
 |---|---|
-| `/gt-{name}` | {description} |
+| `/geno-{name}` | {description} |
 
 ## Repository structure
 
@@ -182,7 +182,7 @@ capabilities:
 name: geno-{name}
 description: >-
   {description}.
-  Use when user says /gt-{name}.
+  Use when user says /geno-{name}.
 license: MIT
 metadata:
   author: 42euge
@@ -197,7 +197,7 @@ metadata:
 
 | Command | Description |
 |---|---|
-| `/gt-{name}` | {description} |
+| `/geno-{name}` | {description} |
 
 ## Runtime
 

--- a/skills/geno-tools/SKILL.md
+++ b/skills/geno-tools/SKILL.md
@@ -2,8 +2,8 @@
 name: geno-tools
 description: >-
   Meta-CLI for installing and managing geno-* skillsets.
-  Use when user says /gt-install, /gt-remove, /gt-ls, /gt-update, /gt-repos-scaffold,
-  /gt-icons-generate, or asks about installing/removing/listing/creating geno ecosystem skillsets.
+  Use when user says /geno-tools-install, /geno-tools-remove, /geno-tools-ls, /geno-tools-update, /geno-tools-repos-scaffold,
+  /geno-tools-icons-generate, or asks about installing/removing/listing/creating geno ecosystem skillsets.
 allowed-tools: "Bash(geno-tools *) Bash(python3 -m genotools *)"
 ---
 


### PR DESCRIPTION
## Summary
Stacked on #14.

- Rename all command files from `gt-*.md` to `geno-tools-*.md`
- Replace every `gt-` reference with canonical skill names across skills, docs, CLAUDE.md, and scaffold templates
- The `gt-` aliasing is tracked as a future user configuration feature in #12

## Test plan
- [ ] `ls commands/` shows `geno-tools-install.md`, `geno-tools-ls.md`, etc.
- [ ] `grep -r "gt-" skills/ commands/ CLAUDE.md docs/` returns zero hits
- [ ] Slash commands still register correctly via `npx skills add`

🤖 Generated with [Claude Code](https://claude.com/claude-code)