### PR TITLE
Add multi-CLI plugin manifests (Codex, Cursor, Gemini, OpenCode)

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,32 @@
+{
+  "name": "geno-tools",
+  "version": "0.1.0",
+  "description": "Meta-CLI for installing and managing geno-* skillsets",
+  "author": {
+    "name": "42euge"
+  },
+  "homepage": "https://github.com/42euge/geno-tools",
+  "repository": "https://github.com/42euge/geno-tools",
+  "license": "MIT",
+  "keywords": [
+    "skillsets",
+    "installer",
+    "meta-cli",
+    "geno-ecosystem"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "geno-tools",
+    "shortDescription": "Install and manage geno-* skillsets for any coding agent",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Install a geno skillset",
+      "List available skillsets"
+    ]
+  }
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,20 +1,20 @@
 {
   "name": "geno-tools",
-  "description": "Meta-CLI for installing and managing geno-* skillsets — the geno ecosystem orchestrator",
+  "displayName": "geno-tools",
   "version": "0.1.0",
+  "description": "Meta-CLI for installing and managing geno-* skillsets",
   "author": {
     "name": "42euge"
   },
   "homepage": "https://github.com/42euge/geno-tools",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/42euge/geno-tools"
-  },
+  "repository": "https://github.com/42euge/geno-tools",
   "license": "MIT",
   "keywords": [
     "skillsets",
     "installer",
     "meta-cli",
     "geno-ecosystem"
-  ]
+  ],
+  "skills": "./skills/",
+  "commands": "./commands/"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,8 @@ venv/
 .vscode/
 .idea/
 
+# Node
+node_modules/
+
 # MkDocs
 site/

--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -1,0 +1,23 @@
+# Installing geno-tools for OpenCode
+
+## 1. Add the plugin
+
+In your `opencode.json`:
+
+```json
+{
+  "plugins": [
+    "geno-tools@git+https://github.com/42euge/geno-tools.git"
+  ]
+}
+```
+
+## 2. Install the Python CLI
+
+```bash
+pipx install git+https://github.com/42euge/geno-tools.git
+```
+
+## 3. Restart OpenCode
+
+The plugin registers geno-tools skills automatically on startup.

--- a/.opencode/plugins/geno-tools.js
+++ b/.opencode/plugins/geno-tools.js
@@ -1,0 +1,18 @@
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { existsSync } from "node:fs";
+
+const __filename = fileURLToPath(import.meta.url);
+const pluginRoot = resolve(dirname(__filename), "..", "..");
+const skillsDir = resolve(pluginRoot, "skills");
+
+export default async function GenoToolsPlugin({ config }) {
+  if (!existsSync(skillsDir)) return;
+
+  config.skills = config.skills || {};
+  config.skills.paths = config.skills.paths || [];
+
+  if (!config.skills.paths.includes(skillsDir)) {
+    config.skills.paths.push(skillsDir);
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,15 +75,25 @@ On failure at any step, the partially created directory is cleaned up.
 
 ## Skill registration
 
-`npx skills add <active-worktree> --agent claude-code --global --skill '*' --yes` fans SKILL.md and commands into `~/.claude/skills/` and `~/.claude/commands/`.
+`npx skills add <active-worktree> --agent '*' --global --skill '*' --yes` registers SKILL.md and commands with all supported agents (Claude Code, Codex, Cursor, Gemini CLI, etc.).
 
 Uninstall enumerates skills (root SKILL.md + `skills/*/SKILL.md`) and calls `npx skills remove`.
 
 ## Plugin structure (this repo)
 
+geno-tools ships platform-specific plugin manifests following the `obra/superpowers` conventions so it can be installed as a native plugin on each supported CLI:
+
 ```
 geno-tools/
 ├── .claude-plugin/plugin.json   # Claude Code plugin manifest
+├── .codex-plugin/plugin.json    # Codex CLI plugin manifest
+├── .cursor-plugin/plugin.json   # Cursor plugin manifest
+├── .opencode/                   # OpenCode plugin
+│   ├── plugins/geno-tools.js    #   ES module plugin (registers skills path)
+│   └── INSTALL.md               #   installation instructions
+├── gemini-extension.json        # Gemini CLI extension descriptor
+├── GEMINI.md                    # Gemini CLI bootstrap context (@-imports SKILL.md)
+├── package.json                 # npm metadata (entry point for OpenCode plugin)
 ├── skills/geno-tools/SKILL.md   # umbrella skill describing the meta-CLI
 ├── commands/                    # slash commands wrapping the CLI
 │   ├── gt-install.md
@@ -97,6 +107,8 @@ geno-tools/
 │   └── registry.py              # curated registry of known skillsets
 └── pyproject.toml               # pip/pipx entry point
 ```
+
+Skills and commands are platform-agnostic. Each CLI-specific manifest points at the shared `skills/` and `commands/` directories.
 
 ## What a skillset repo needs to provide
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+@./skills/geno-tools/SKILL.md

--- a/README.md
+++ b/README.md
@@ -1,21 +1,49 @@
 # geno-tools
 
-Meta-CLI for installing and managing [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skillsets in the `geno-*` ecosystem.
+Meta-CLI for installing and managing coding agent skillsets in the `geno-*` ecosystem. Works with Claude Code, Codex, Gemini CLI, Cursor, and OpenCode.
 
 ## What it does
 
-`geno-tools` installs/uninstalls/dev-links curated skillset repos (each a `geno-{name}` repo with its own `genotools.yaml` manifest) into agent targets — Claude Code first, Codex and Gemini CLI to follow. Inspired by [vercel-labs/skills](https://github.com/vercel-labs/skills), specialized for this ecosystem:
+`geno-tools` installs/uninstalls/dev-links curated skillset repos (each a `geno-{name}` repo) into any supported coding agent. Inspired by [vercel-labs/skills](https://github.com/vercel-labs/skills) and [obra/superpowers](https://github.com/obra/superpowers), specialized for this ecosystem:
 
 - **Curated registry** — short names (`media`, `research`, `taxes`, …) resolve to git URLs
-- **Declarative install** — each skillset's `genotools.yaml` declares its venv deps, runtime symlinks, and config defaults
+- **Multi-agent** — skills register with all agents via `npx skills add --agent '*'`
 - **Per-skillset venvs** — isolated at `~/.geno-tools/geno-{name}/venvs/`
-- **Copy-once configs** — user edits preserved across updates
 - **Dev-link** — point at a local checkout for meta-improvement
 
 ## Install
 
+### Python CLI (required for all platforms)
+
 ```bash
 pipx install git+https://github.com/42euge/geno-tools
+```
+
+### Claude Code
+
+```bash
+claude /plugin install 42euge/geno-tools
+```
+
+### Codex CLI
+
+Clone and symlink skills into `~/.agents/skills/geno-tools`, then install the Python CLI above.
+
+### Gemini CLI
+
+```bash
+gemini extensions install https://github.com/42euge/geno-tools
+```
+
+### Cursor
+
+Install via plugin manager or clone to your Cursor plugins directory.
+
+### OpenCode
+
+Add to `opencode.json`:
+```json
+{ "plugins": ["geno-tools@git+https://github.com/42euge/geno-tools.git"] }
 ```
 
 ## Usage

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -2,14 +2,18 @@
 
 geno-tools is structured around a few core concepts:
 
-## Dual installation
+## Multi-agent installation
 
-geno-tools itself can be installed two ways:
+geno-tools can be installed as a native plugin on any supported coding CLI:
 
-- **Claude Code plugin** — `claude /plugin install 42euge/geno-tools` adds slash commands (`/gt-install`, `/gt-ls`, etc.) inside Claude Code
+- **Claude Code** — `claude /plugin install 42euge/geno-tools`
+- **Codex CLI** — clone + symlink to `~/.agents/skills/geno-tools`
+- **Cursor** — install via plugin manager
+- **Gemini CLI** — `gemini extensions install https://github.com/42euge/geno-tools`
+- **OpenCode** — add `"geno-tools@git+https://github.com/42euge/geno-tools.git"` to `opencode.json` plugins
 - **Python CLI** — `pipx install git+https://github.com/42euge/geno-tools` puts the `geno-tools` binary on your PATH
 
-The plugin wraps the CLI, so both paths require the Python package. The ecosystem skillsets geno-tools installs remain skills-based (registered via `npx skills add`).
+All plugin paths wrap the Python CLI, so they require the Python package installed. The ecosystem skillsets geno-tools installs are registered with all agents via `npx skills add --agent '*'`.
 
 ## Source resolution
 
@@ -32,7 +36,7 @@ geno-tools install media
         ├── create venv + editable install (if pyproject.toml exists)
         ├── symlink [project.scripts] binaries into ~/.local/bin/
         ├── set active -> main symlink
-        └── npx skills add (register skills with Claude Code)
+        └── npx skills add --agent '*' (register skills with all agents)
 ```
 
 On failure at any step, the partially created `~/.geno-tools/geno-{name}/` directory is cleaned up automatically.
@@ -41,19 +45,27 @@ On failure at any step, the partially created `~/.geno-tools/geno-{name}/` direc
 
 Removal reverses the install:
 
-1. `npx skills remove` — unregister skills from Claude Code
+1. `npx skills remove` — unregister skills from all agents
 2. Remove `~/.local/bin/` symlinks that point into this skillset's venv
 3. Delete `~/.geno-tools/geno-{name}/` (or preserve venvs/worktrees with `--keep-data`)
 
 ## Plugin structure
 
-The geno-tools repo ships both a Python package and a Claude Code plugin:
+The geno-tools repo ships platform-specific plugin manifests (following `obra/superpowers` conventions) alongside the Python CLI:
 
 ```
 geno-tools/
 ├── .claude-plugin/plugin.json   # Claude Code plugin manifest
-├── skills/geno-tools/SKILL.md   # umbrella skill describing the meta-CLI
-├── commands/                    # slash commands wrapping the CLI
+├── .codex-plugin/plugin.json    # Codex CLI plugin manifest
+├── .cursor-plugin/plugin.json   # Cursor plugin manifest
+├── .opencode/                   # OpenCode plugin
+│   ├── plugins/geno-tools.js    #   ES module (registers skills path)
+│   └── INSTALL.md
+├── gemini-extension.json        # Gemini CLI extension descriptor
+├── GEMINI.md                    # Gemini CLI bootstrap context
+├── package.json                 # npm metadata (OpenCode entry point)
+├── skills/geno-tools/SKILL.md   # umbrella skill (platform-agnostic)
+├── commands/                    # slash commands (platform-agnostic)
 │   ├── gt-install.md
 │   ├── gt-remove.md
 │   ├── gt-ls.md
@@ -65,6 +77,8 @@ geno-tools/
 │   └── registry.py
 └── pyproject.toml               # pip/pipx entry point
 ```
+
+Skills and commands are shared across all platforms. Each CLI has its own manifest that points at these shared directories.
 
 ## Pages
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,6 @@
+{
+  "name": "geno-tools",
+  "description": "Meta-CLI for installing and managing geno-* skillsets",
+  "version": "0.1.0",
+  "contextFileName": "GEMINI.md"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "geno-tools",
+  "version": "0.1.0",
+  "type": "module",
+  "main": ".opencode/plugins/geno-tools.js"
+}


### PR DESCRIPTION
## Summary

- Add platform-specific plugin manifests following `obra/superpowers` conventions so geno-tools is installable as a native plugin on **Codex CLI, Cursor, Gemini CLI, and OpenCode** — in addition to the existing Claude Code plugin
- Enrich existing `.claude-plugin/plugin.json` with `homepage`, `license`, `keywords`
- Update docs (CLAUDE.md, architecture, README) to reflect multi-agent support

## New files

| File | Purpose |
|------|---------|
| `.codex-plugin/plugin.json` | Codex CLI manifest with `interface` block |
| `.cursor-plugin/plugin.json` | Cursor manifest with `skills` + `commands` pointers |
| `gemini-extension.json` | Gemini CLI extension descriptor |
| `GEMINI.md` | Bootstrap context (`@`-imports umbrella SKILL.md) |
| `.opencode/plugins/geno-tools.js` | ES module plugin (registers skills path) |
| `.opencode/INSTALL.md` | OpenCode installation instructions |
| `package.json` | npm entry point for OpenCode plugin system |

## Test plan

- [ ] Validate all JSON manifests: `python3 -c "import json; json.load(open('<file>'))"`
- [ ] Validate JS syntax: `node --check .opencode/plugins/geno-tools.js`
- [ ] Verify version `0.1.0` consistent across all manifests, `pyproject.toml`, `__init__.py`
- [ ] Verify `GEMINI.md` `@`-reference resolves to `skills/geno-tools/SKILL.md`
- [ ] Test Claude Code plugin install: `claude /plugin install 42euge/geno-tools`

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)