### PR TITLE
Add skillset dependency management via requires:

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,23 @@ geno-tools = "genotools.cli:main"
 | `geno-tools fork <name> <variant> [--isolated-venv]` | stub |
 | `geno-tools use <name>@<variant> [--here]` | stub |
 | `geno-tools promote <name> <variant>` | stub |
+| `geno-tools deps <name>` | implemented |
 | `geno-tools doctor` | stub |
+
+## Dependency management
+
+Skillsets declare dependencies via `requires:` in `genotools.yaml`:
+
+```yaml
+name: geno-career
+requires:
+  - geno-notes
+  - geno-specs
+```
+
+During `geno-tools install`, dependencies are resolved from the registry and installed recursively before the target skillset. Already-installed deps are skipped. Circular dependencies are detected and reported.
+
+`geno-tools deps <name>` prints the dependency tree for an installed skillset.
 
 ## Command prefix aliasing
 
@@ -123,6 +139,7 @@ Minimum viable `geno-{name}` skillset:
 ```
 geno-{name}/
 ├── SKILL.md                # umbrella skill manifest
+├── genotools.yaml          # optional — install manifest with requires:
 ├── commands/
 │   └── {name}-*.md         # slash commands (any *.md works)
 └── pyproject.toml           # optional — triggers venv creation if present

--- a/genotools/cli.py
+++ b/genotools/cli.py
@@ -44,6 +44,9 @@ def main(argv: list[str] | None = None) -> int:
     p_rm.add_argument("--keep-data", action="store_true",
                       help="preserve venvs/ and worktrees")
 
+    p_deps = sub.add_parser("deps", help="show dependency tree for a skillset")
+    p_deps.add_argument("name", help="skillset name")
+
     sub.add_parser("doctor", help="verify symlinks, worktrees, venvs")
 
     p_disc = sub.add_parser("discover", help="list candidate skillsets from configured sources")

--- a/genotools/commands.py
+++ b/genotools/commands.py
@@ -9,6 +9,8 @@ import sys
 import tomllib
 from pathlib import Path
 
+import yaml
+
 from genotools import config, discovery, paths, registry
 
 SYSTEM_BIN = Path.home() / ".local" / "bin"
@@ -24,6 +26,7 @@ def dispatch(args: argparse.Namespace) -> int:
         "promote": _promote,
         "update": _update,
         "remove": _remove,
+        "deps": _deps,
         "doctor": _doctor,
         "discover": _discover,
     }
@@ -62,29 +65,58 @@ def _ls(args: argparse.Namespace) -> int:
     return 0
 
 
+# ── manifest ───────────────────────────────────────────────────────────────
+
+def _read_manifest(full: str) -> dict:
+    worktree = paths.skillset_worktree(full, "main")
+    manifest = worktree / "genotools.yaml"
+    if not manifest.exists():
+        return {}
+    try:
+        return yaml.safe_load(manifest.read_text()) or {}
+    except Exception:
+        return {}
+
+
+def _get_requires(full: str) -> list[str]:
+    manifest = _read_manifest(full)
+    raw = manifest.get("requires", [])
+    if not isinstance(raw, list):
+        return []
+    return [str(r) for r in raw]
+
+
 # ── install ─────────────────────────────────────────────────────────────────
 
 def _install(args: argparse.Namespace) -> int:
     if args.here:
         return _todo(f"install --here {args.name}: cwd alias materialization")
-
     config.ensure_dir()
+    return _install_one(args.name, installing=set())
 
-    source, name = _resolve_source(args.name)
+
+def _install_one(name_or_source: str, *, installing: set[str]) -> int:
+    source, name = _resolve_source(name_or_source)
     if name is None:
         name = _peek_repo_name(source)
     full = paths.normalize(name)
 
     if paths.skillset_root(full).exists():
-        print(f"already installed: {full} "
-              f"(remove first: geno-tools remove {full})", file=sys.stderr)
+        print(f"already installed: {full}")
+        return 0
+
+    if full in installing:
+        print(f"  circular dependency detected: {full}; skipping",
+              file=sys.stderr)
         return 1
+    installing.add(full)
 
     print(f"installing {full} from {source}")
     root = paths.skillset_root(full)
     root.mkdir(parents=True)
     try:
         _clone_and_worktree(source, full)
+        _install_requires(full, installing)
         scripts = _create_venv_if_needed(full)
         _materialize_bin_symlinks(full, scripts)
         paths.skillset_active(full).symlink_to("main")
@@ -95,6 +127,23 @@ def _install(args: argparse.Namespace) -> int:
 
     print(f"installed {full}")
     return 0
+
+
+def _install_requires(full: str, installing: set[str]) -> None:
+    requires = _get_requires(full)
+    if not requires:
+        return
+    print(f"  {full} requires: {', '.join(requires)}")
+    for dep in requires:
+        dep_full = paths.normalize(dep)
+        if paths.skillset_root(dep_full).exists():
+            continue
+        print(f"  installing dependency: {dep}")
+        rc = _install_one(dep, installing=installing)
+        if rc != 0:
+            raise SystemExit(
+                f"failed to install dependency {dep} required by {full}"
+            )
 
 
 # ── remove ──────────────────────────────────────────────────────────────────
@@ -319,6 +368,38 @@ def _enumerate_skills(full: str) -> list[str]:
             if p.is_dir() and (p / "SKILL.md").exists()
         ))
     return names
+
+
+# ── deps ───────────────────────────────────────────────────────────────────
+
+def _deps(args: argparse.Namespace) -> int:
+    full = paths.normalize(args.name)
+    if not paths.skillset_root(full).exists():
+        print(f"not installed: {full}", file=sys.stderr)
+        return 1
+
+    _print_dep_tree(full, indent=0, seen=set())
+    return 0
+
+
+def _print_dep_tree(full: str, indent: int, seen: set[str]) -> None:
+    prefix = "  " * indent
+    installed = paths.skillset_root(full).exists()
+    marker = "" if installed else " (missing)"
+    print(f"{prefix}{full}{marker}")
+
+    if full in seen:
+        if _get_requires(full):
+            print(f"{prefix}  (circular, skipped)")
+        return
+    seen.add(full)
+
+    if not installed:
+        return
+
+    for dep in _get_requires(full):
+        dep_full = paths.normalize(dep)
+        _print_dep_tree(dep_full, indent + 1, seen)
 
 
 # ── stubs (later phases) ────────────────────────────────────────────────────

--- a/genotools/registry.py
+++ b/genotools/registry.py
@@ -38,8 +38,10 @@ _FALLBACK: dict[str, str] = {
     "geno-agents":   f"https://github.com/{OWNER}/geno-agents.git",
     "geno-media":    f"https://github.com/{OWNER}/geno-media.git",
     "geno-research": f"https://github.com/{OWNER}/geno-research.git",
+    "geno-taxes":    f"https://github.com/{OWNER}/geno-taxes.git",
     "geno-kaggle":   f"https://github.com/{OWNER}/geno-kaggle.git",
     "geno-dev":      f"https://github.com/{OWNER}/geno-dev.git",
+    "geno-specs":    f"https://github.com/{OWNER}/geno-specs.git",
 }
 
 _cache: dict[str, str] | None = None


### PR DESCRIPTION
## Summary

- Skillsets can declare dependencies via `requires:` in `genotools.yaml`
- `geno-tools install` resolves and installs missing deps recursively from the registry before the target skillset
- Circular dependencies are detected and reported
- New `geno-tools deps <name>` subcommand prints the dependency tree with missing-dep markers
- Added `geno-specs` to the registry fallback map

## Example

```yaml
# genotools.yaml
name: geno-career
requires:
  - geno-notes
  - geno-specs
```

```
$ geno-tools deps career
geno-career
  geno-notes
  geno-specs
    geno-agents
```

## Test plan

- [ ] `geno-tools install` on a skillset with `requires:` pulls in deps first
- [ ] Already-installed deps are skipped (no re-clone)
- [ ] Circular dependency is detected and reported without infinite loop
- [ ] `geno-tools deps <name>` shows the tree for an installed skillset
- [ ] `geno-tools deps <name>` marks uninstalled deps as `(missing)`
- [ ] Skillsets without `genotools.yaml` or without `requires:` install normally

Closes #19