### PR TITLE
Drop pipx install path; ship as plugin only

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,23 @@
+{
+  "name": "geno-tools",
+  "owner": {
+    "name": "42euge",
+    "url": "https://github.com/42euge"
+  },
+  "plugins": [
+    {
+      "name": "geno-tools",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/42euge/geno-tools"
+      },
+      "description": "Meta-CLI for installing and managing geno-* skillsets — the geno ecosystem orchestrator",
+      "version": "0.1.0",
+      "license": "MIT",
+      "homepage": "https://github.com/42euge/geno-tools",
+      "policy": {
+        "installation": "AVAILABLE"
+      }
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,24 @@
+{
+  "name": "geno-tools",
+  "owner": {
+    "name": "42euge",
+    "url": "https://github.com/42euge"
+  },
+  "plugins": [
+    {
+      "name": "geno-tools",
+      "source": "./",
+      "description": "Meta-CLI for installing and managing geno-* skillsets — the geno ecosystem orchestrator",
+      "version": "0.1.0",
+      "license": "MIT",
+      "homepage": "https://github.com/42euge/geno-tools",
+      "repository": "https://github.com/42euge/geno-tools",
+      "keywords": [
+        "skillsets",
+        "installer",
+        "meta-cli",
+        "geno-ecosystem"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,13 +3,11 @@
   "description": "Meta-CLI for installing and managing geno-* skillsets — the geno ecosystem orchestrator",
   "version": "0.1.0",
   "author": {
-    "name": "42euge"
+    "name": "42euge",
+    "url": "https://github.com/42euge"
   },
   "homepage": "https://github.com/42euge/geno-tools",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/42euge/geno-tools"
-  },
+  "repository": "https://github.com/42euge/geno-tools",
   "license": "MIT",
   "keywords": [
     "skillsets",

--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -12,12 +12,6 @@ In your `opencode.json`:
 }
 ```
 
-## 2. Install the Python CLI
-
-```bash
-pipx install git+https://github.com/42euge/geno-tools.git
-```
-
-## 3. Restart OpenCode
+## 2. Restart OpenCode
 
 The plugin registers geno-tools skills automatically on startup.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,10 @@
 # geno-tools — skillset manager for the geno ecosystem
 
-`geno-tools` is a meta-CLI and Claude Code plugin (Python, `pipx install geno-tools`) that installs sibling `geno-{name}` repos as coding agent skillsets. It handles cloning, venvs, bin symlinks, and skill registration via `npx skills`.
+`geno-tools` is a meta-CLI and Claude Code plugin that installs sibling `geno-{name}` repos as coding agent skillsets. It handles cloning, venvs, bin symlinks, and skill registration via `npx skills`.
 
-## Dual installation
+## Installation
 
-- **Claude Code plugin**: `.claude-plugin/plugin.json` + `skills/` expose the geno-tools skill
-- **Python CLI**: `pyproject.toml` → `geno-tools` binary on PATH via pipx/pip
-
-The plugin wraps the CLI — both require the Python package installed.
+geno-tools is distributed exclusively as a coding-agent plugin — there is no pipx/pip path. Each supported CLI installs it via its native plugin mechanism (`claude /plugin install`, `gemini extensions install`, OpenCode `plugins`, the Cursor plugin manager, or Codex symlink). `.claude-plugin/plugin.json` + the shared `skills/` directory expose the geno-tools skill across all platforms.
 
 ## Entry point
 
@@ -114,7 +111,7 @@ geno-tools/
 │   ├── config.py                # user config from ~/.geno/config.yaml
 │   ├── paths.py                 # on-disk layout utilities
 │   └── registry.py              # curated registry of known skillsets
-└── pyproject.toml               # pip/pipx entry point
+└── pyproject.toml               # Python package metadata
 ```
 
 Skills are platform-agnostic. Each CLI-specific manifest points at the shared `skills/` directory.

--- a/README.md
+++ b/README.md
@@ -13,17 +13,27 @@ Meta-CLI for installing and managing coding agent skillsets in the `geno-*` ecos
 
 ## Install
 
-geno-tools installs as a native plugin on each supported coding agent.
+geno-tools ships as a native plugin/extension on each supported coding CLI. Pick the snippet for the CLI you use — every path bootstraps `~/.geno/` from `config/defaults.yaml` on first session start.
 
 ### Claude Code
 
 ```bash
-claude /plugin install 42euge/geno-tools
+# inside a Claude Code session
+/plugin marketplace add 42euge/geno-tools
+/plugin install geno-tools@geno-tools
 ```
+
+The first command registers this repo as a marketplace (reads `.claude-plugin/marketplace.json`); the second installs the plugin defined in `.claude-plugin/plugin.json`. Verify with `/plugin list`.
 
 ### Codex CLI
 
-Clone and symlink skills into `~/.agents/skills/geno-tools`.
+```bash
+# inside a Codex CLI session
+/plugin marketplace add 42euge/geno-tools
+/plugins
+```
+
+The marketplace catalog at `.agents/plugins/marketplace.json` exposes the plugin; pick `geno-tools` from the `/plugins` browser and toggle it on. (Plugins are cached at `~/.codex/plugins/cache/geno-tools/geno-tools/<version>/`.)
 
 ### Gemini CLI
 
@@ -31,16 +41,32 @@ Clone and symlink skills into `~/.agents/skills/geno-tools`.
 gemini extensions install https://github.com/42euge/geno-tools
 ```
 
+Gemini clones the repo into `~/.gemini/extensions/geno-tools/`, reads `gemini-extension.json`, and registers the bundled `skills/`, `commands/`, and `hooks/hooks.json`. Restart the CLI to pick it up. Update later with `gemini extensions update geno-tools`.
+
 ### Cursor
 
-Install via plugin manager or clone to your Cursor plugins directory.
+Install via Cursor's plugin manager (it reads `.cursor-plugin/plugin.json`), or clone the repo into your Cursor plugins directory.
 
 ### OpenCode
 
 Add to `opencode.json`:
+
 ```json
 { "plugins": ["geno-tools@git+https://github.com/42euge/geno-tools.git"] }
 ```
+
+Then restart OpenCode — the bundled plugin in `.opencode/plugins/geno-tools.js` registers the skills path on startup.
+
+### Verify
+
+In any CLI, the slash commands appear immediately after install:
+
+```
+/gt-ls --available     # list registry
+/gt-install geno-<name>
+```
+
+If `geno-tools` isn't on PATH after a plugin install (some CLIs don't auto-symlink the venv binary), the `/gt-*` slash commands will surface an install hint pointing back to the plugin install for that CLI.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,7 @@ Meta-CLI for installing and managing coding agent skillsets in the `geno-*` ecos
 
 ## Install
 
-### Python CLI (required for all platforms)
-
-```bash
-pipx install git+https://github.com/42euge/geno-tools
-```
+geno-tools installs as a native plugin on each supported coding agent.
 
 ### Claude Code
 
@@ -27,7 +23,7 @@ claude /plugin install 42euge/geno-tools
 
 ### Codex CLI
 
-Clone and symlink skills into `~/.agents/skills/geno-tools`, then install the Python CLI above.
+Clone and symlink skills into `~/.agents/skills/geno-tools`.
 
 ### Gemini CLI
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -4,16 +4,15 @@ geno-tools is structured around a few core concepts:
 
 ## Multi-agent installation
 
-geno-tools can be installed as a native plugin on any supported coding CLI:
+geno-tools is installed as a native plugin on each supported coding CLI:
 
 - **Claude Code** — `claude /plugin install 42euge/geno-tools`
 - **Codex CLI** — clone + symlink to `~/.agents/skills/geno-tools`
 - **Cursor** — install via plugin manager
 - **Gemini CLI** — `gemini extensions install https://github.com/42euge/geno-tools`
 - **OpenCode** — add `"geno-tools@git+https://github.com/42euge/geno-tools.git"` to `opencode.json` plugins
-- **Python CLI** — `pipx install git+https://github.com/42euge/geno-tools` puts the `geno-tools` binary on your PATH
 
-All plugin paths wrap the Python CLI, so they require the Python package installed. The ecosystem skillsets geno-tools installs are registered with all agents via `npx skills add --agent '*'`.
+Each plugin manifest points at the shared `skills/` directory and the bundled Python package, so a plugin install is sufficient — there is no separate pipx/pip step. The ecosystem skillsets geno-tools manages are registered with all agents via `npx skills add --agent '*'`.
 
 ## Source resolution
 
@@ -76,7 +75,7 @@ geno-tools/
 │   ├── commands.py
 │   ├── paths.py
 │   └── registry.py
-└── pyproject.toml               # pip/pipx entry point
+└── pyproject.toml               # Python package metadata
 ```
 
 Skills and commands are shared across all platforms. Each CLI has its own manifest that points at these shared directories.

--- a/docs/docs-home.md
+++ b/docs/docs-home.md
@@ -3,7 +3,7 @@
 # geno-<span>tools</span>
 
 The package manager for AI coding agent skillsets.
-Install, fork, experiment, promote — as a Claude Code plugin or standalone CLI.
+Install, fork, experiment, promote — as a native plugin in your coding agent.
 
 <div class="hero-buttons">
 <a href="getting-started/" class="btn-primary">Get Started</a>
@@ -19,7 +19,7 @@ Install, fork, experiment, promote — as a Claude Code plugin or standalone CLI
 
 ### Install in seconds
 
-Install as a Claude Code plugin or via `pipx`. Short names resolve from a curated registry.
+Install as a Claude Code plugin or its equivalent on Codex, Cursor, Gemini CLI, or OpenCode. Short names resolve from a curated registry.
 
 [Get started :material-arrow-right:](getting-started.md)
 </div>
@@ -60,29 +60,28 @@ Fork a skillset, experiment in isolation, promote back to main. Git worktrees un
 
 ## Quick taste
 
-=== "Claude Code plugin"
+=== "Claude Code"
 
     ```bash
     claude /plugin install 42euge/geno-tools
-    pipx install git+https://github.com/42euge/geno-tools
 
     /gt-ls --available                       # see the registry
     /gt-install geno-<name>                  # install a skillset
-    geno-tools fork geno-<name> exp-1        # branch a variant
-    geno-tools use geno-<name>@exp-1         # activate it
-    geno-tools promote geno-<name> exp-1     # merge back to main
+    /gt-fork geno-<name> exp-1               # branch a variant
+    /gt-use geno-<name>@exp-1                # activate it
+    /gt-promote geno-<name> exp-1            # merge back to main
     ```
 
-=== "CLI only"
+=== "Gemini CLI"
 
     ```bash
-    pipx install git+https://github.com/42euge/geno-tools
+    gemini extensions install https://github.com/42euge/geno-tools
 
-    geno-tools ls --available                # see the registry
-    geno-tools install geno-<name>           # install a skillset
-    geno-tools fork geno-<name> exp-1        # branch a variant
-    geno-tools use geno-<name>@exp-1         # activate it
-    geno-tools promote geno-<name> exp-1     # merge back to main
+    /gt-ls --available                       # see the registry
+    /gt-install geno-<name>                  # install a skillset
+    /gt-fork geno-<name> exp-1               # branch a variant
+    /gt-use geno-<name>@exp-1                # activate it
+    /gt-promote geno-<name> exp-1            # merge back to main
     ```
 
 </div>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,48 +4,42 @@
 
 - Git
 - Node.js (for `npx skills`)
-- Python 3.11+ (for the CLI install path)
+- Python 3.11+
 
 ## Install geno-tools
 
-geno-tools can be installed as a **Claude Code plugin** or as a **standalone CLI** — pick whichever fits your workflow, or use both.
+geno-tools is installed as a native plugin in your coding agent. Pick the manifest that matches the CLI you use:
 
-### Option A: Claude Code plugin
+### Claude Code
 
 ```bash
 claude /plugin install 42euge/geno-tools
 ```
 
-This gives you `/gt-install`, `/gt-remove`, `/gt-ls`, and `/gt-update` slash commands inside Claude Code. The plugin wraps the CLI, so you still need the CLI on your PATH for the slash commands to work:
+This gives you `/gt-install`, `/gt-remove`, `/gt-ls`, and `/gt-update` slash commands inside Claude Code.
+
+### Gemini CLI
 
 ```bash
-pipx install git+https://github.com/42euge/geno-tools
+gemini extensions install https://github.com/42euge/geno-tools
 ```
 
-### Option B: CLI only
+### Codex CLI / Cursor / OpenCode
 
-```bash
-pipx install git+https://github.com/42euge/geno-tools
+See the [README](https://github.com/42euge/geno-tools#install) for the per-agent install snippet.
+
+Verify the install by listing the registry from inside your agent:
+
 ```
-
-Or with pip:
-
-```bash
-pip install git+https://github.com/42euge/geno-tools
-```
-
-Verify the install:
-
-```bash
-geno-tools --version
+/gt-ls --available
 ```
 
 ## Install your first skillset
 
 List what's available in the registry:
 
-```bash
-geno-tools ls --available
+```
+/gt-ls --available
 ```
 
 ```
@@ -58,16 +52,16 @@ geno-tools ls --available
 
 Install one:
 
-```bash
-geno-tools install geno-<name>
+```
+/gt-install geno-<name>
 ```
 
 This clones the repo, sets up any declared venvs, and wires the skill into your coding agent (slash commands appear immediately).
 
 ## Check what's installed
 
-```bash
-geno-tools ls
+```
+/gt-ls
 ```
 
 ```
@@ -78,8 +72,8 @@ geno-tools ls
 
 If you're hacking on a skillset, use `dev` to symlink your local checkout instead of cloning:
 
-```bash
-geno-tools dev geno-<name> ~/src/geno-<name>
+```
+/gt-dev geno-<name> ~/src/geno-<name>
 ```
 
 Edits to your local checkout take effect immediately — no reinstall needed.

--- a/genotools/commands.py
+++ b/genotools/commands.py
@@ -9,7 +9,7 @@ import sys
 import tomllib
 from pathlib import Path
 
-from genotools import discovery, paths, registry
+from genotools import config, discovery, paths, registry
 
 SYSTEM_BIN = Path.home() / ".local" / "bin"
 
@@ -67,6 +67,8 @@ def _ls(args: argparse.Namespace) -> int:
 def _install(args: argparse.Namespace) -> int:
     if args.here:
         return _todo(f"install --here {args.name}: cwd alias materialization")
+
+    config.ensure_dir()
 
     source, name = _resolve_source(args.name)
     if name is None:

--- a/genotools/config.py
+++ b/genotools/config.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import shutil
 import yaml
 from pathlib import Path
 
 CONFIG_DIR = Path.home() / ".geno"
 CONFIG_FILE = CONFIG_DIR / "config.yaml"
+
+_DEFAULTS_SOURCE = Path(__file__).resolve().parent.parent / "config" / "defaults.yaml"
 
 _DEFAULTS = {
     "aliases": {
@@ -18,6 +21,21 @@ _DEFAULTS = {
         ],
     },
 }
+
+
+def ensure_dir() -> Path:
+    """Create ~/.geno/ (and seed config.yaml from defaults) if missing.
+
+    Called on install so a fresh machine ends up with the expected user
+    config directory without any extra setup step.
+    """
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    if not CONFIG_FILE.exists():
+        if _DEFAULTS_SOURCE.exists():
+            shutil.copyfile(_DEFAULTS_SOURCE, CONFIG_FILE)
+        else:
+            CONFIG_FILE.write_text(yaml.safe_dump(_DEFAULTS, sort_keys=False))
+    return CONFIG_DIR
 
 
 def load() -> dict:

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,6 +7,12 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/init-geno-dir.sh"
+          },
+          {
+            "name": "geno-tools-init",
+            "type": "command",
+            "command": "${extensionPath}/scripts/init-geno-dir.sh",
+            "timeout": 5000
           }
         ]
       }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/init-geno-dir.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/init-geno-dir.sh
+++ b/scripts/init-geno-dir.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Materialize ~/.geno/ on session start so the geno-tools CLI and
+# every skillset that reads ~/.geno/config.yaml has a config to read.
+# Idempotent: skips the copy if the file already exists.
+set -euo pipefail
+
+target_dir="${HOME}/.geno"
+target_file="${target_dir}/config.yaml"
+default_config="${CLAUDE_PLUGIN_ROOT:-}/config/defaults.yaml"
+
+mkdir -p "${target_dir}"
+
+if [[ ! -e "${target_file}" && -f "${default_config}" ]]; then
+  cp "${default_config}" "${target_file}"
+fi

--- a/scripts/init-geno-dir.sh
+++ b/scripts/init-geno-dir.sh
@@ -2,11 +2,19 @@
 # Materialize ~/.geno/ on session start so the geno-tools CLI and
 # every skillset that reads ~/.geno/config.yaml has a config to read.
 # Idempotent: skips the copy if the file already exists.
+#
+# Works under any coding CLI that supports a SessionStart hook —
+# Claude Code exports ${CLAUDE_PLUGIN_ROOT}; Gemini CLI does not, so
+# we fall back to resolving the plugin root from the script's own
+# location (scripts/ sits one level under the plugin root).
 set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+plugin_root="${CLAUDE_PLUGIN_ROOT:-${script_dir%/scripts}}"
 
 target_dir="${HOME}/.geno"
 target_file="${target_dir}/config.yaml"
-default_config="${CLAUDE_PLUGIN_ROOT:-}/config/defaults.yaml"
+default_config="${plugin_root}/config/defaults.yaml"
 
 mkdir -p "${target_dir}"
 

--- a/skills/geno-tools/SKILL.md
+++ b/skills/geno-tools/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools: "Bash(geno-tools *) Bash(python3 -m genotools *)"
 Orchestrator for the geno-* ecosystem. Manages installation, removal, and updates of skillset repos.
 
 ```!
-which geno-tools >/dev/null 2>&1 || echo "geno-tools CLI not on PATH. Install: pipx install git+https://github.com/42euge/geno-tools.git"
+which geno-tools >/dev/null 2>&1 || echo "geno-tools CLI not on PATH. Install via your coding agent's plugin manager (e.g. 'claude /plugin install 42euge/geno-tools' or 'gemini extensions install https://github.com/42euge/geno-tools')."
 ```
 
 ## Available Skillsets


### PR DESCRIPTION
Documentation now points users at the per-agent plugin install (Claude
Code, Gemini CLI, Codex, Cursor, OpenCode) instead of pipx/pip. The CLAUDE.md
overview, README install table, getting-started walkthrough, architecture
overview, OpenCode INSTALL, docs landing page, and the geno-tools skill
preflight message are all updated accordingly.