### PR TITLE
Add docs site link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Meta-CLI for installing and managing coding agent skillsets in the `geno-*` ecosystem. Works with Claude Code, Codex, Gemini CLI, Cursor, and OpenCode.
 
+**Website:** <https://42euge.github.io/geno-tools>
+
 ## What it does
 
 `geno-tools` installs/uninstalls/dev-links curated skillset repos (each a `geno-{name}` repo) into any supported coding agent. Inspired by [vercel-labs/skills](https://github.com/vercel-labs/skills) and [obra/superpowers](https://github.com/obra/superpowers), specialized for this ecosystem:


### PR DESCRIPTION
## Summary
- Surface the mkdocs-material site (`https://42euge.github.io/geno-tools`) at the top of the README so it's discoverable from the GitHub repo page.

## Test plan
- [ ] Confirm the link renders as expected on github.com/42euge/geno-tools
- [ ] Confirm the URL still points at the live mkdocs site

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZGxEnkJqH1qK3ExqnoLFJ)_