### PR TITLE
Drop broken ${extensionPath} hook entry from Claude plugin

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,12 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/init-geno-dir.sh"
-          },
-          {
-            "name": "geno-tools-init",
-            "type": "command",
-            "command": "${extensionPath}/scripts/init-geno-dir.sh",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/init-geno-dir.sh",
             "timeout": 5000
           }
         ]


### PR DESCRIPTION
hooks/hooks.json is the Claude Code plugin hooks file (auto-discovered
at <plugin-root>/hooks/hooks.json). Claude only substitutes
${CLAUDE_PLUGIN_ROOT}; ${extensionPath} is a Gemini parse-time variable
that Claude leaves unsubstituted, after which bash expands it to empty
and the hook tries to exec /scripts/init-geno-dir.sh and fails.

The earlier "each CLI resolves its own variable" assumption (1760c78)
was wrong: Claude executes every entry in hooks.json, and Gemini
doesn't read hooks/hooks.json at all (its hooks live in
gemini-extension.json). So the second entry was broken for Claude and
unused by Gemini.

Keep a single ${CLAUDE_PLUGIN_ROOT} entry with the 5s timeout; the
script's BASH_SOURCE-based fallback still covers direct invocation.