### PR TITLE
Declare skills path in Claude plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -14,5 +14,6 @@
     "installer",
     "meta-cli",
     "geno-ecosystem"
-  ]
+  ],
+  "skills": "./skills"
 }


### PR DESCRIPTION
Without "skills": "./skills" in .claude-plugin/plugin.json, Claude Code
loads the plugin but never discovers SKILL.md files in skills/, so
/reload-plugins reports 0 skills and slash commands like
/geno-tools:geno-tools return "Unknown command".

Fixes #27