### PR TITLE
Add open-docs skill

### DIFF
--- a/skills/geno-tools-open-docs/SKILL.md
+++ b/skills/geno-tools-open-docs/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: geno-tools-open-docs
 description: >-
-  Open the geno-tools documentation website in the default browser.
+  Open the current repo's GitHub Pages documentation site in the default browser.
   Use when user says /geno-tools-open-docs, /gt-open-docs, or asks to
-  open/view the geno-tools docs site.
-allowed-tools: "Bash(open *) Bash(gh api *) Bash(git remote *)"
+  open/view the docs website.
+allowed-tools: "Bash(open *) Bash(gh api *) Bash(git *)"
 license: MIT
 metadata:
   author: 42euge
@@ -13,28 +13,25 @@ metadata:
 
 # geno-tools-open-docs — Open Documentation Site
 
-Open the geno-tools GitHub Pages documentation site in the default browser.
+Open the GitHub Pages documentation site for the current repo in the default browser.
 
 ## Behavior
 
-1. Determine the docs URL from the git remote:
+1. Get the GitHub Pages URL for the current repo:
    ```bash
-   REMOTE_URL=$(git -C ~/.geno-tools/geno-tools/active remote get-url origin 2>/dev/null \
-     || git remote get-url origin 2>/dev/null \
-     || echo "https://github.com/42euge/geno-tools")
+   gh api repos/{owner}/{repo}/pages --jq '.html_url'
    ```
-2. Derive the GitHub Pages URL from the remote (e.g. `42euge/geno-tools` → `https://42euge.github.io/geno-tools/`).
-3. Open it:
+2. Open it:
    ```bash
    open "$PAGES_URL"
    ```
-4. Print the URL so the user can see it.
+3. Print the URL so the user can see it.
 
 If the argument is a subpath (e.g. `/geno-tools-open-docs architecture`), append it to the URL:
 ```bash
-open "https://42euge.github.io/geno-tools/architecture/"
+open "${PAGES_URL}architecture/"
 ```
 
 ## Fallback
 
-If the remote can't be resolved, use the hardcoded URL: `https://42euge.github.io/geno-tools/`
+If `gh api` fails (no Pages configured, not a GitHub repo, etc.), tell the user that GitHub Pages isn't enabled for this repo.

--- a/skills/geno-tools-open-docs/SKILL.md
+++ b/skills/geno-tools-open-docs/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: geno-tools-open-docs
+description: >-
+  Open the geno-tools documentation website in the default browser.
+  Use when user says /geno-tools-open-docs, /gt-open-docs, or asks to
+  open/view the geno-tools docs site.
+allowed-tools: "Bash(open *) Bash(gh api *) Bash(git remote *)"
+license: MIT
+metadata:
+  author: 42euge
+  version: "0.1.0"
+---
+
+# geno-tools-open-docs — Open Documentation Site
+
+Open the geno-tools GitHub Pages documentation site in the default browser.
+
+## Behavior
+
+1. Determine the docs URL from the git remote:
+   ```bash
+   REMOTE_URL=$(git -C ~/.geno-tools/geno-tools/active remote get-url origin 2>/dev/null \
+     || git remote get-url origin 2>/dev/null \
+     || echo "https://github.com/42euge/geno-tools")
+   ```
+2. Derive the GitHub Pages URL from the remote (e.g. `42euge/geno-tools` → `https://42euge.github.io/geno-tools/`).
+3. Open it:
+   ```bash
+   open "$PAGES_URL"
+   ```
+4. Print the URL so the user can see it.
+
+If the argument is a subpath (e.g. `/geno-tools-open-docs architecture`), append it to the URL:
+```bash
+open "https://42euge.github.io/geno-tools/architecture/"
+```
+
+## Fallback
+
+If the remote can't be resolved, use the hardcoded URL: `https://42euge.github.io/geno-tools/`


### PR DESCRIPTION
## Summary
- Adds `geno-tools-open-docs` skill that opens the GitHub Pages docs site (`https://42euge.github.io/geno-tools/`) in the default browser
- Supports optional subpath argument (e.g. `/gt-open-docs architecture`)
- Resolves the URL from the git remote with a hardcoded fallback

## Test plan
- [ ] `/geno-tools-open-docs` opens docs site in browser
- [ ] `/geno-tools-open-docs architecture` opens the architecture subpage