### PR TITLE
Update homepage URLs to point to GitHub Pages site

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -14,7 +14,7 @@
       "description": "Meta-CLI for installing and managing geno-* skillsets — the geno ecosystem orchestrator",
       "version": "0.1.0",
       "license": "MIT",
-      "homepage": "https://github.com/42euge/geno-tools",
+      "homepage": "https://42euge.github.io/geno-tools",
       "policy": {
         "installation": "AVAILABLE"
       }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "description": "Meta-CLI for installing and managing geno-* skillsets — the geno ecosystem orchestrator",
       "version": "0.1.0",
       "license": "MIT",
-      "homepage": "https://github.com/42euge/geno-tools",
+      "homepage": "https://42euge.github.io/geno-tools",
       "repository": "https://github.com/42euge/geno-tools",
       "keywords": [
         "skillsets",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "42euge",
     "url": "https://github.com/42euge"
   },
-  "homepage": "https://github.com/42euge/geno-tools",
+  "homepage": "https://42euge.github.io/geno-tools",
   "repository": "https://github.com/42euge/geno-tools",
   "license": "MIT",
   "keywords": [

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "42euge"
   },
-  "homepage": "https://github.com/42euge/geno-tools",
+  "homepage": "https://42euge.github.io/geno-tools",
   "repository": "https://github.com/42euge/geno-tools",
   "license": "MIT",
   "keywords": [

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -6,7 +6,7 @@
   "author": {
     "name": "42euge"
   },
-  "homepage": "https://github.com/42euge/geno-tools",
+  "homepage": "https://42euge.github.io/geno-tools",
   "repository": "https://github.com/42euge/geno-tools",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
## Summary
Updated the homepage URL across all plugin configuration files to point to the GitHub Pages documentation site instead of the GitHub repository.

## Changes
- Updated homepage URL from `https://github.com/42euge/geno-tools` to `https://42euge.github.io/geno-tools` in:
  - `.agents/plugins/marketplace.json`
  - `.claude-plugin/marketplace.json`
  - `.claude-plugin/plugin.json`
  - `.codex-plugin/plugin.json`
  - `.cursor-plugin/plugin.json`

## Details
The repository URL remains unchanged and continues to point to the GitHub repository. Only the homepage field has been updated to direct users to the dedicated GitHub Pages documentation site for the geno-tools project. This provides a better user experience by separating the project documentation from the source code repository.

https://claude.ai/code/session_01SpPydVL3GRRzc5i8znt2fz