### PR TITLE
Update docs to use canonical prefixes and modern conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,12 +192,6 @@ How it works in practice:
 
 The result: sensitive prompts, datasets, and domain knowledge stay inside the company boundary, while the runtime, the file format, and the multi-agent integrations are the same fast-moving open-source code everyone else uses. You inherit upstream improvements without giving up control of your skill content.
 
-## Legacy (transitional)
-
-Some slash commands still live in this repo's `commands/` — `gt-start-task`, `gt-rewrite-commit`, `gt-config-colab`, `gt-upload-colab`, `gt-upload-kaggle`. These will migrate into `geno-dev` and `geno-kaggle` as those repos come online. Lab notes have moved to the [`geno-notes`](https://github.com/42euge/geno-notes) repo (use `/gt-notes`).
-
-A legacy `install.sh` is still present to wire up the remaining commands and colab config. It will be removed once everything is extracted.
-
 ## License
 
 MIT

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2,11 +2,11 @@
 
 All commands are invoked as `geno-tools <command> [options]`.
 
-If geno-tools is installed as a Claude Code plugin, the core commands are also available as slash commands: `/gt-install`, `/gt-remove`, `/gt-ls`, `/gt-update`.
+When geno-tools is installed as a coding agent plugin, the core commands are also available as slash commands: `/geno-tools install`, `/geno-tools remove`, `/geno-tools ls`, `/geno-tools update`. The command prefix is [user-configurable](skillsets/creating.md#command-prefix-aliasing).
 
 ## `ls`
 
-List installed skillsets or the available registry. Slash command: `/gt-ls`.
+List installed skillsets or the available registry. Slash command: `/geno-tools ls`.
 
 ```bash
 geno-tools ls                # installed skillsets + active variant
@@ -23,7 +23,7 @@ geno-tools ls --available    # curated registry
 
 ## `install`
 
-Install a skillset from the registry, a git URL, or a local path. Slash command: `/gt-install`.
+Install a skillset from the registry, a git URL, or a local path. Slash command: `/geno-tools install`.
 
 ```bash
 geno-tools install geno-<name>
@@ -130,7 +130,7 @@ geno-tools promote geno-<name> exp-1
 
 ## `update`
 
-Pull latest changes on the main worktree. Slash command: `/gt-update`.
+Pull latest changes on the main worktree. Slash command: `/geno-tools update`.
 
 ```bash
 geno-tools update geno-<name>    # update one
@@ -149,7 +149,7 @@ Skips skillsets in `dev` mode (the source is already live).
 
 ## `remove`
 
-Uninstall a skillset. Replays the install in reverse — deterministic, no orphaned files. Slash command: `/gt-remove`.
+Uninstall a skillset. Replays the install in reverse — deterministic, no orphaned files. Slash command: `/geno-tools remove`.
 
 ```bash
 geno-tools remove geno-<name>

--- a/docs/docs-home.md
+++ b/docs/docs-home.md
@@ -66,11 +66,11 @@ Fork a skillset, experiment in isolation, promote back to main. Git worktrees un
     /plugin marketplace add 42euge/geno-tools
     /plugin install geno-tools@geno-tools
 
-    /gt-ls --available                       # see the registry
-    /gt-install geno-<name>                  # install a skillset
-    /gt-fork geno-<name> exp-1               # branch a variant
-    /gt-use geno-<name>@exp-1                # activate it
-    /gt-promote geno-<name> exp-1            # merge back to main
+    /geno-tools ls --available               # see the registry
+    /geno-tools install geno-<name>          # install a skillset
+    /geno-tools fork geno-<name> exp-1       # branch a variant
+    /geno-tools use geno-<name>@exp-1        # activate it
+    /geno-tools promote geno-<name> exp-1    # merge back to main
     ```
 
 === "Gemini CLI"
@@ -79,11 +79,11 @@ Fork a skillset, experiment in isolation, promote back to main. Git worktrees un
     gemini extensions install https://github.com/42euge/geno-tools
     bash ~/.gemini/extensions/geno-tools/scripts/bootstrap.sh
 
-    /gt-ls --available                       # see the registry
-    /gt-install geno-<name>                  # install a skillset
-    /gt-fork geno-<name> exp-1               # branch a variant
-    /gt-use geno-<name>@exp-1                # activate it
-    /gt-promote geno-<name> exp-1            # merge back to main
+    /geno-tools ls --available               # see the registry
+    /geno-tools install geno-<name>          # install a skillset
+    /geno-tools fork geno-<name> exp-1       # branch a variant
+    /geno-tools use geno-<name>@exp-1        # activate it
+    /geno-tools promote geno-<name> exp-1    # merge back to main
     ```
 
 </div>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,7 +21,7 @@ Inside a Claude Code session:
 
 The first command registers this repo as a marketplace (reads `.claude-plugin/marketplace.json`); the second installs the plugin defined in `.claude-plugin/plugin.json`. The SessionStart hook then runs `scripts/bootstrap.sh`, which materializes `~/.geno/config.yaml` and pipx-installs the `geno-tools` CLI if it isn't already on PATH. Verify with `/plugin list`.
 
-This gives you `/gt-install`, `/gt-remove`, `/gt-ls`, and `/gt-update` slash commands inside Claude Code.
+This gives you `/geno-tools install`, `/geno-tools remove`, `/geno-tools ls`, and `/geno-tools update` slash commands inside your coding agent. The command prefix is [user-configurable](skillsets/creating.md#command-prefix-aliasing).
 
 ### Gemini CLI
 
@@ -39,7 +39,7 @@ See the [README](https://github.com/42euge/geno-tools#install) for the per-agent
 Verify the install by listing the registry from inside your agent:
 
 ```
-/gt-ls --available
+/geno-tools ls --available
 ```
 
 ## Install your first skillset
@@ -47,7 +47,7 @@ Verify the install by listing the registry from inside your agent:
 List what's available in the registry:
 
 ```
-/gt-ls --available
+/geno-tools ls --available
 ```
 
 ```
@@ -61,7 +61,7 @@ List what's available in the registry:
 Install one:
 
 ```
-/gt-install geno-<name>
+/geno-tools install geno-<name>
 ```
 
 This clones the repo, sets up any declared venvs, and wires the skill into your coding agent (slash commands appear immediately).
@@ -69,7 +69,7 @@ This clones the repo, sets up any declared venvs, and wires the skill into your 
 ## Check what's installed
 
 ```
-/gt-ls
+/geno-tools ls
 ```
 
 ```
@@ -81,7 +81,7 @@ This clones the repo, sets up any declared venvs, and wires the skill into your 
 If you're hacking on a skillset, use `dev` to symlink your local checkout instead of cloning:
 
 ```
-/gt-dev geno-<name> ~/src/geno-<name>
+/geno-tools dev geno-<name> ~/src/geno-<name>
 ```
 
 Edits to your local checkout take effect immediately — no reinstall needed.

--- a/docs/onboarding/audit.md
+++ b/docs/onboarding/audit.md
@@ -41,13 +41,15 @@ For enterprise, capture the result as a signed artifact (PR description, interna
 - [ ] `allowed-tools` (when present) is the minimum needed. Reject blanket `Bash(*)` if the skill only needs a few commands.
 - [ ] Subskillsets under `skills/<subskill>/SKILL.md` follow the same rules. Each is audited individually.
 
-### 3. Slash commands (`commands/*.md`)
+### 3. Skills (`skills/*/SKILL.md`)
 
-- [ ] Filenames follow the prefix convention so users see consistent `/{prefix}-*` naming.
-- [ ] No command shells out via untrusted input without quoting/escaping.
-- [ ] No command writes outside `~/.geno-tools/{repo}/`, the user's working directory, or explicit user-confirmed paths.
-- [ ] No command touches another skillset's directory.
-- [ ] Side-effecting commands (network calls, deletes, pushes, sends) require user confirmation in the prompt.
+- [ ] Skill directory names follow the [nomenclature](../skillsets/nomenclature.md) convention: `{skillset}-{sub-skillset}-{skill}`.
+- [ ] The `name` field in each SKILL.md frontmatter matches its directory name.
+- [ ] All slash command references in `description` fields and body content use the canonical `geno-` prefix, not aliased prefixes like `gt-`. The command prefix is [user-configurable](../skillsets/creating.md#command-prefix-aliasing) and applied at install time.
+- [ ] No skill shells out via untrusted input without quoting/escaping.
+- [ ] No skill writes outside `~/.geno-tools/{repo}/`, the user's working directory, or explicit user-confirmed paths.
+- [ ] No skill touches another skillset's directory.
+- [ ] Side-effecting skills (network calls, deletes, pushes, sends) require user confirmation in the prompt.
 
 ### 4. Code, dependencies, and runtime
 
@@ -111,6 +113,6 @@ For minor updates already covered by a previous full audit, run a delta audit:
 
 1. `git diff <last-audited-ref>..<new-ref>` — confirm only docs/comment changes.
 2. `git diff -- pyproject.toml requirements*.txt` — confirm no dep changes.
-3. `git diff -- 'SKILL.md' 'skills/**/SKILL.md' 'commands/**'` — confirm no prompt or command changes.
+3. `git diff -- 'SKILL.md' 'skills/**/SKILL.md'` — confirm no prompt or skill changes.
 
 If any of those return non-trivial diffs, escalate to a full audit.

--- a/docs/onboarding/index.md
+++ b/docs/onboarding/index.md
@@ -21,7 +21,7 @@ The checklist is the same. The reviewer changes.
 
 ## Onboarding a public skillset
 
-1. **Author the repo.** Follow [Creating a Skillset](../skillsets/creating.md). Minimum viable: a root `SKILL.md` and a `commands/` directory.
+1. **Author the repo.** Follow [Creating a Skillset](../skillsets/creating.md). Minimum viable: a `genotools.yaml`, a root `SKILL.md`, a `GENO.md`, and a `skills/` directory.
 2. **Self-test.** `geno-tools dev <repo-name> ~/src/<repo-name>` to install from a local checkout, then exercise every slash command.
 3. **Push to a public git remote.** Anyone can already install it via direct URL at this point: `geno-tools install https://github.com/you/your-skillset.git`.
 4. **Open a registry PR.** Add `"<repo-name>": "<git-url>"` to `genotools/registry.py` and the corresponding row to `docs/skillsets/index.md` and the README's existing-repos table.

--- a/docs/skillsets/creating.md
+++ b/docs/skillsets/creating.md
@@ -6,10 +6,17 @@ Build your own `geno-{name}` skillset that geno-tools can install, update, and m
 
 ```
 geno-myskill/
-├── genotools.yaml      # required — the manifest
-├── SKILL.md            # umbrella description for the agent
-└── commands/
-    └── gt-myskill.md   # at least one slash command
+├── genotools.yaml                # required — install manifest
+├── GENO.md                       # agent instructions (single source of truth)
+├── SKILL.md                      # umbrella skill manifest
+├── CLAUDE.md                     # pointer: @./GENO.md
+├── GEMINI.md                     # pointer: @./GENO.md
+├── AGENTS.md                     # pointer: @import GENO.md
+└── skills/
+    ├── geno-myskill/             # umbrella skill
+    │   └── SKILL.md
+    └── geno-myskill-tasks-start/ # at least one sub-skill
+        └── SKILL.md
 ```
 
 ## The manifest — `genotools.yaml`
@@ -35,10 +42,6 @@ runtime:
 # Optional — copy-once config defaults (preserved across updates)
 config:
   - { src: config/defaults/settings.yaml, dst: settings.yaml }
-
-# Optional — override the commands directory (default: "commands/")
-commands:
-  source: commands/
 ```
 
 ### Required fields
@@ -80,32 +83,100 @@ Copy-once files into `~/.geno-tools/geno-{name}/configs/`. Only created if missi
 | `src` | Path relative to repo root |
 | `dst` | Path relative to configs dir |
 
-## SKILL.md
+## Skills — `skills/`
 
-The umbrella manifest that describes your skillset to the agent. Use YAML frontmatter:
+Skills are defined as `SKILL.md` files under `skills/`. Each skill lives in its own directory. The directory name must match the `name` field in the SKILL.md frontmatter.
 
-```markdown
+### Naming convention
+
+Skills follow a three-level hierarchy: `{skillset}-{sub-skillset}-{skill}`. See [Nomenclature](nomenclature.md) for the full spec.
+
+- **Sub-skillset** — a pluralized noun (e.g. `tasks`, `sessions`, `notebooks`)
+- **Skill** — an action verb (e.g. `start`, `create`, `manage`)
+- **Umbrella** — just the skillset name, no suffix
+
+Example layout:
+
+```
+skills/
+├── geno-myskill/                    # umbrella
+│   └── SKILL.md
+├── geno-myskill-tasks-start/        # sub-skillset: tasks, skill: start
+│   └── SKILL.md
+└── geno-myskill-configs-export/     # sub-skillset: configs, skill: export
+    └── SKILL.md
+```
+
+### SKILL.md frontmatter
+
+```yaml
 ---
-name: geno-myskill
+name: geno-myskill-tasks-start
 description: >-
-  What this skillset does and when to use it.
-  Use when user says /gt-myskill.
+  Start a task from the project journal.
+  Use when user says /geno-myskill-tasks-start.
+allowed-tools: "Bash(find *) Read(*)"
 license: MIT
 metadata:
   author: your-username
   version: "0.1.0"
 ---
-
-# geno-myskill
-
-Description, install instructions, command table, runtime notes.
 ```
 
-## Slash commands
+### Umbrella SKILL.md
 
-Each `.md` file in `commands/` becomes a `/gt-*` slash command. The filename (minus `.md`) is the command name.
+The root `SKILL.md` at the repo root is the umbrella manifest. It describes the entire skillset and lists all available sub-skill commands in its `description` field. This is what agents read to understand what the skillset can do.
 
-Write these as instructions for the agent — what to do when the user invokes the command, what tools to use, what output to produce.
+## Agent instruction files
+
+### GENO.md — the single source of truth
+
+`GENO.md` at the repo root is the canonical instruction file that any agent reads to understand the repo. It should contain:
+
+1. **Title and summary** — one-line description of the skillset
+2. **Skills table** — every skill with its name and slash command
+3. **Repo structure** — tree of key files and directories
+4. **Conventions** — rules for modifying code in this repo, including:
+    - How skills are named in this repo
+    - SKILL.md frontmatter format
+    - Checklist for adding a new skill
+    - Command prefix aliasing (see below)
+
+### Per-agent pointer files
+
+Each agent looks for a different filename. Create thin pointers — no content, just an import:
+
+| File | Content |
+|------|---------|
+| `CLAUDE.md` | `@./GENO.md` |
+| `GEMINI.md` | `@./GENO.md` |
+| `AGENTS.md` | `@import GENO.md` |
+
+This way, updating `GENO.md` updates every agent at once.
+
+## Command prefix aliasing
+
+Slash commands use a configurable prefix. Users set their preferred prefix in `~/.geno/config.yaml`:
+
+```yaml
+aliases:
+  command_prefix: "gt"   # /gt-myskill, /gt-myskill-tasks-start
+  # or "geno"            # /geno-myskill, /geno-myskill-tasks-start
+  # or ""                # /myskill, /myskill-tasks-start
+```
+
+The prefix is applied at install time by `geno-tools install`. **Repo source files must always use the canonical `geno-` prefix.** Never hardcode `gt-` or any other alias in:
+
+- SKILL.md `description` fields
+- SKILL.md body content
+- GENO.md skills tables and section headers
+- README.md, docs, or any committed file
+
+The canonical name is the skill's `name` field in frontmatter — use that everywhere.
+
+## Agent-agnostic language
+
+The geno ecosystem is CLI-agnostic — skillsets work with Claude Code, Gemini CLI, Codex, OpenCode, and any future coding agent. Use generic terms like "coding agent" or "agent session" instead of naming a specific agent. When listing prerequisites, mention the supported agents generically.
 
 ## Testing locally
 
@@ -132,5 +203,9 @@ _FALLBACK: dict[str, str] = {
 }
 ```
 
+## Compliance
+
+Run `geno-audit` against your repo before submitting. It checks all ecosystem conventions — manifest, skills, naming, GENO.md content, aliasing, docs, and more. See the [audit process](../onboarding/audit.md) for details.
+
 !!! note "Skillsets vs. plugins"
-    Ecosystem skillsets use the skills format (`SKILL.md` + `commands/*.md`) and are installed via `geno-tools install`. Only geno-tools itself ships as a Claude Code plugin (`.claude-plugin/plugin.json`) to provide the `/gt-install`, `/gt-remove`, `/gt-ls`, and `/gt-update` slash commands.
+    Ecosystem skillsets use the skills format (`SKILL.md` + `skills/`) and are installed via `geno-tools install`. Only geno-tools itself ships as a coding agent plugin to provide the install, remove, and list commands.

--- a/docs/skillsets/index.md
+++ b/docs/skillsets/index.md
@@ -24,8 +24,9 @@ geno-tools install geno-<name>
 
 When you install a skillset, you get:
 
-- **Slash commands** — markdown files that appear as `/gt-*` commands in your coding agent
+- **Skills** — `SKILL.md` files under `skills/` that register as slash commands in your coding agent (the command prefix is [user-configurable](creating.md#command-prefix-aliasing))
 - **SKILL.md** — an umbrella manifest describing the skillset's capabilities
+- **GENO.md** — agent instructions, the single source of truth read by all supported coding agents
 - **Runtime scripts** (optional) — Python/shell scripts symlinked for command use
 - **Config defaults** (optional) — copy-once configs that preserve user edits across updates
 - **Isolated venvs** (optional) — Python dependencies that don't pollute your system

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
   - Skillsets:
       - skillsets/index.md
       - Creating a Skillset: skillsets/creating.md
+      - Nomenclature: skillsets/nomenclature.md
   - Onboarding:
       - onboarding/index.md
       - Audit Process: onboarding/audit.md

--- a/skills/geno-tools-open-docs/SKILL.md
+++ b/skills/geno-tools-open-docs/SKILL.md
@@ -2,8 +2,8 @@
 name: geno-tools-open-docs
 description: >-
   Open the current repo's GitHub Pages documentation site in the default browser.
-  Use when user says /geno-tools-open-docs, /gt-open-docs, or asks to
-  open/view the docs website.
+  Use when user says /geno-tools-open-docs or asks to open/view the
+  docs website.
 allowed-tools: "Bash(open *) Bash(gh api *) Bash(git *)"
 license: MIT
 metadata:


### PR DESCRIPTION
## Summary

- Replace all hardcoded `/gt-*` slash command references with canonical `/geno-tools *` forms across all docs, README, and SKILL.md files
- Rewrite `docs/skillsets/creating.md` to document the modern skillset structure: `skills/` directory (not legacy `commands/`), `GENO.md` as single source of truth, per-agent pointer files, command prefix aliasing, nomenclature, and agent-agnostic language
- Update `docs/onboarding/audit.md` checklist to reference `skills/*/SKILL.md` instead of `commands/*.md`, add aliasing and nomenclature checks
- Add nomenclature page to mkdocs nav
- Remove obsolete "Legacy" section from README (the `commands/` directory no longer exists)
- Fix `geno-tools-open-docs` SKILL.md to drop aliased `/gt-open-docs` trigger

## Test plan

- [ ] Run `mkdocs serve` and verify all pages render correctly with no broken links
- [ ] Verify no remaining `/gt-` hardcoded references in docs (except config examples showing what the `gt` prefix produces)
- [ ] Check that `creating.md` covers all ecosystem conventions: GENO.md, skills/, aliasing, nomenclature, agent-agnostic language