### PR TITLE
Implement geno-tools update command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ geno-tools = "genotools.cli:main"
 | `geno-tools ls [--available]` | implemented |
 | `geno-tools install <name\|url\|path> [--here]` | implemented |
 | `geno-tools remove <name> [--keep-data]` | implemented |
-| `geno-tools update [name]` | stub |
+| `geno-tools update [name]` | implemented |
 | `geno-tools dev <name> <path>` | stub |
 | `geno-tools fork <name> <variant> [--isolated-venv]` | stub |
 | `geno-tools use <name>@<variant> [--here]` | stub |

--- a/genotools/commands.py
+++ b/genotools/commands.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import sys
 import tomllib
+from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
@@ -430,7 +431,173 @@ def _promote(args: argparse.Namespace) -> int:
 
 
 def _update(args: argparse.Namespace) -> int:
-    return _todo(f"update {args.name or '<all>'}")
+    if args.name:
+        full = paths.normalize(args.name)
+        if not paths.skillset_root(full).exists():
+            print(f"not installed: {full}", file=sys.stderr)
+            return 1
+        results = [_update_one(full)]
+    else:
+        if not paths.ROOT.exists():
+            print("no skillsets installed")
+            return 0
+        installed = sorted(
+            p.name for p in paths.ROOT.iterdir()
+            if p.is_dir() and p.name.startswith("geno-")
+            and p.name not in ("geno-bootstrap",)
+        )
+        if not installed:
+            print("no skillsets installed")
+            return 0
+        results = [_update_one(full) for full in installed]
+
+    _print_update_summary(results)
+    return 1 if any(r.status == "error" for r in results) else 0
+
+
+@dataclass
+class _UpdateResult:
+    name: str
+    status: str  # "updated" | "up-to-date" | "skipped" | "error"
+    detail: str = ""
+    old_rev: str = ""
+    new_rev: str = ""
+
+
+def _update_one(full: str) -> _UpdateResult:
+    bare = paths.skillset_git(full)
+    worktree = paths.skillset_worktree(full, "main")
+
+    if not worktree.exists():
+        return _UpdateResult(full, "error", "main worktree missing")
+
+    if worktree.is_symlink():
+        return _UpdateResult(full, "skipped", "dev mode (local symlink)")
+
+    try:
+        status = subprocess.check_output(
+            ["git", "-C", str(worktree), "status", "--porcelain"],
+            text=True,
+        ).strip()
+    except subprocess.CalledProcessError:
+        return _UpdateResult(full, "error", "git status failed")
+
+    if status:
+        return _UpdateResult(full, "skipped", "dirty worktree")
+
+    default_branch = _detect_default_branch(bare)
+
+    try:
+        current_branch = subprocess.check_output(
+            ["git", "-C", str(worktree), "branch", "--show-current"],
+            text=True,
+        ).strip()
+    except subprocess.CalledProcessError:
+        return _UpdateResult(full, "error", "cannot detect branch")
+
+    if current_branch != default_branch:
+        return _UpdateResult(
+            full, "skipped",
+            f"on branch '{current_branch}', not '{default_branch}'",
+        )
+
+    try:
+        old_rev = subprocess.check_output(
+            ["git", "-C", str(worktree), "rev-parse", "HEAD"],
+            text=True,
+        ).strip()
+    except subprocess.CalledProcessError:
+        old_rev = ""
+
+    print(f"  fetching {full}...")
+    try:
+        subprocess.check_call(
+            ["git", "-C", str(bare), "fetch", "--quiet", "origin"],
+        )
+    except subprocess.CalledProcessError:
+        return _UpdateResult(full, "error", "git fetch failed")
+
+    try:
+        subprocess.check_call(
+            ["git", "-C", str(worktree), "pull", "--ff-only", "--quiet",
+             "origin", default_branch],
+        )
+    except subprocess.CalledProcessError:
+        return _UpdateResult(full, "error", "git pull --ff-only failed (diverged?)")
+
+    try:
+        new_rev = subprocess.check_output(
+            ["git", "-C", str(worktree), "rev-parse", "HEAD"],
+            text=True,
+        ).strip()
+    except subprocess.CalledProcessError:
+        new_rev = ""
+
+    if old_rev == new_rev:
+        return _UpdateResult(full, "up-to-date", old_rev=old_rev[:8])
+
+    _maybe_reinstall_venv(full, old_rev, new_rev)
+    _install_skills_via_npx(full)
+
+    return _UpdateResult(full, "updated", old_rev=old_rev[:8], new_rev=new_rev[:8])
+
+
+def _maybe_reinstall_venv(full: str, old_rev: str, new_rev: str) -> None:
+    worktree = paths.skillset_worktree(full, "main")
+    if not (worktree / "pyproject.toml").exists():
+        return
+
+    try:
+        changed = subprocess.check_output(
+            ["git", "-C", str(worktree), "diff", "--name-only",
+             old_rev, new_rev],
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        changed = "pyproject.toml"
+
+    if "pyproject.toml" not in changed:
+        return
+
+    venv_dir = paths.skillset_venvs(full) / "default"
+    if not venv_dir.exists():
+        _create_venv_if_needed(full)
+        return
+
+    print(f"  pyproject.toml changed; reinstalling venv...")
+    pip = venv_dir / "bin" / "pip"
+    try:
+        subprocess.check_call(
+            [str(pip), "install", "--quiet", "-e", str(worktree)]
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"  warn: venv reinstall failed for {full}: {e}",
+              file=sys.stderr)
+
+
+def _print_update_summary(results: list[_UpdateResult]) -> None:
+    updated = [r for r in results if r.status == "updated"]
+    up_to_date = [r for r in results if r.status == "up-to-date"]
+    skipped = [r for r in results if r.status == "skipped"]
+    errors = [r for r in results if r.status == "error"]
+
+    print()
+    if updated:
+        print(f"updated ({len(updated)}):")
+        for r in updated:
+            print(f"  {r.name:<24} {r.old_rev} -> {r.new_rev}")
+    if up_to_date:
+        print(f"already up-to-date ({len(up_to_date)}):")
+        for r in up_to_date:
+            print(f"  {r.name}")
+    if skipped:
+        print(f"skipped ({len(skipped)}):")
+        for r in skipped:
+            print(f"  {r.name:<24} {r.detail}")
+    if errors:
+        print(f"errors ({len(errors)}):")
+        for r in errors:
+            print(f"  {r.name:<24} {r.detail}")
 
 
 def _doctor(_: argparse.Namespace) -> int:

--- a/skills/geno-audit/SKILL.md
+++ b/skills/geno-audit/SKILL.md
@@ -443,6 +443,21 @@ This rule applies to install commands. For the general rule about slash command 
 
 ---
 
+## Ecosystem Freshness
+
+Installed skillsets should stay on the latest main branch. Stale installs lead to agents using outdated skill definitions, missing features, and broken cross-skillset interactions. `geno-tools update` pulls the latest main for all installed skillsets (or a specific one) and re-registers skills.
+
+### Audit checks
+
+**Recommended:**
+- Run `geno-tools update` as part of the audit to ensure the target repo's installed copy (if any) is on the latest main. If the installed copy is behind origin, the audit should note how many commits behind it is.
+- If the target repo's `main` worktree at `~/.geno-tools/geno-{name}/main/` has a dirty working tree or is on a non-default branch, warn that the install is in a non-standard state.
+
+**Info:**
+- Report the current installed revision (short SHA) and the date of the last commit on main. Stale installs older than 30 days get an INFO note.
+
+---
+
 ## Command Prefix Aliasing in Repo Source
 
 Slash commands in the geno ecosystem use a configurable prefix. Users set their preferred prefix in `~/.geno/config.yaml`:
@@ -563,7 +578,7 @@ A repo's `GENO.md` should contain a skills table showing what skills *this* repo
 
 2. **Detect the repo name.** Use the directory basename.
 
-3. **Run all checks.** For each section (`.geno` Convention, Manifest, SKILL.md, Skill Nomenclature, Agent Instruction Files, Documentation, Repo Hygiene, Agent-Agnostic Language, Installation Compliance, Command Prefix Aliasing in Repo Source, Single Source of Truth Enforcement), check every item at every tier. For each check, determine PASS, FAIL, WARN, or INFO and collect a short reason for non-PASS results.
+3. **Run all checks.** For each section (`.geno` Convention, Manifest, SKILL.md, Skill Nomenclature, Agent Instruction Files, Documentation, Repo Hygiene, Agent-Agnostic Language, Installation Compliance, Ecosystem Freshness, Command Prefix Aliasing in Repo Source, Single Source of Truth Enforcement), check every item at every tier. For each check, determine PASS, FAIL, WARN, or INFO and collect a short reason for non-PASS results.
 
 4. **Parse YAML carefully.** Use Python for YAML parsing:
    ```bash

--- a/skills/geno-tools-update/SKILL.md
+++ b/skills/geno-tools-update/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: geno-tools-update
+description: >-
+  Update installed geno ecosystem skillsets to the latest main branch.
+  Use when user says /geno-tools-update, asks to update the ecosystem,
+  pull latest, or sync repos.
+allowed-tools: "Bash(geno-tools *)"
+license: MIT
+metadata:
+  author: 42euge
+  version: "0.1.0"
+---
+
+# geno-tools-update — Update Ecosystem Repos
+
+Pull the latest main branch for installed geno-* skillsets, re-register skills, and reinstall venvs if dependencies changed.
+
+## Usage
+
+Update all installed skillsets:
+```bash
+geno-tools update
+```
+
+Update a single skillset:
+```bash
+geno-tools update <name>
+```
+
+The `<name>` accepts both full (`geno-dev`) and bare (`dev`) forms.
+
+## Behavior
+
+For each skillset the command will:
+1. Fetch from origin
+2. Fast-forward the main worktree to the latest commit
+3. Reinstall the Python venv if `pyproject.toml` changed
+4. Re-register skills via `npx skills add` if any SKILL.md files changed
+
+Skillsets are **skipped** (not errored) when:
+- The worktree has uncommitted changes (dirty)
+- The worktree is on a branch other than the default
+- The skillset is in dev mode (local symlink)
+
+A summary is printed at the end showing updated, up-to-date, skipped, and errored repos.

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,364 @@
+"""Tests for geno-tools update — pull latest main for installed skillsets."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from genotools import commands, paths
+
+
+# ── _update_one ──────────────────────────────────────────────────────────
+
+
+class TestUpdateOne:
+    def test_up_to_date(self, fake_skillset, monkeypatch):
+        fake_skillset("geno-dev")
+        rev = "abc12345"
+
+        def fake_check_output(cmd, **kw):
+            if "status" in cmd and "--porcelain" in cmd:
+                return ""
+            if "branch" in cmd and "--show-current" in cmd:
+                return "main"
+            if "rev-parse" in cmd:
+                return rev
+            if "diff" in cmd and "--name-only" in cmd:
+                return ""
+            return ""
+
+        monkeypatch.setattr("subprocess.check_output", fake_check_output)
+        monkeypatch.setattr("subprocess.check_call", lambda cmd, **kw: None)
+
+        result = commands._update_one("geno-dev")
+        assert result.status == "up-to-date"
+        assert result.old_rev == rev[:8]
+
+    def test_updated_with_skill_re_registration(self, fake_skillset, monkeypatch):
+        fake_skillset("geno-dev", sub_skills=["geno-dev-a"])
+        call_count = {"rev": 0}
+        npx_calls = []
+
+        def fake_check_output(cmd, **kw):
+            if "status" in cmd and "--porcelain" in cmd:
+                return ""
+            if "branch" in cmd and "--show-current" in cmd:
+                return "main"
+            if "rev-parse" in cmd:
+                call_count["rev"] += 1
+                return "old12345678" if call_count["rev"] == 1 else "new56789abc"
+            if "symbolic-ref" in cmd:
+                return "main"
+            if "diff" in cmd and "--name-only" in cmd:
+                return "README.md"
+            return ""
+
+        def fake_check_call(cmd, **kw):
+            if cmd[0] == "npx":
+                npx_calls.append(cmd)
+
+        monkeypatch.setattr("subprocess.check_output", fake_check_output)
+        monkeypatch.setattr("subprocess.check_call", fake_check_call)
+
+        result = commands._update_one("geno-dev")
+        assert result.status == "updated"
+        assert result.old_rev == "old12345"
+        assert result.new_rev == "new56789"
+        assert len(npx_calls) == 2  # umbrella + 1 sub-skill
+
+    def test_dirty_worktree_skipped(self, fake_skillset, monkeypatch):
+        fake_skillset("geno-dev")
+
+        def fake_check_output(cmd, **kw):
+            if "status" in cmd and "--porcelain" in cmd:
+                return "M README.md\n"
+            return ""
+
+        monkeypatch.setattr("subprocess.check_output", fake_check_output)
+
+        result = commands._update_one("geno-dev")
+        assert result.status == "skipped"
+        assert "dirty" in result.detail
+
+    def test_wrong_branch_skipped(self, fake_skillset, monkeypatch):
+        fake_skillset("geno-dev")
+
+        def fake_check_output(cmd, **kw):
+            if "status" in cmd and "--porcelain" in cmd:
+                return ""
+            if "branch" in cmd and "--show-current" in cmd:
+                return "feature-branch"
+            if "symbolic-ref" in cmd:
+                return "main"
+            return ""
+
+        monkeypatch.setattr("subprocess.check_output", fake_check_output)
+
+        result = commands._update_one("geno-dev")
+        assert result.status == "skipped"
+        assert "feature-branch" in result.detail
+
+    def test_dev_mode_skipped(self, tmp_root):
+        root = tmp_root / "geno-dev"
+        root.mkdir()
+        (root / ".git").mkdir()
+        real_main = tmp_root / "real-checkout"
+        real_main.mkdir()
+        (root / "main").symlink_to(real_main)
+        (root / "active").symlink_to("main")
+
+        result = commands._update_one("geno-dev")
+        assert result.status == "skipped"
+        assert "dev mode" in result.detail
+
+    def test_missing_worktree_error(self, tmp_root):
+        root = tmp_root / "geno-dev"
+        root.mkdir()
+        (root / ".git").mkdir()
+        (root / "active").symlink_to("main")
+
+        result = commands._update_one("geno-dev")
+        assert result.status == "error"
+        assert "missing" in result.detail
+
+    def test_fetch_failure(self, fake_skillset, monkeypatch):
+        fake_skillset("geno-dev")
+
+        def fake_check_output(cmd, **kw):
+            if "status" in cmd and "--porcelain" in cmd:
+                return ""
+            if "branch" in cmd and "--show-current" in cmd:
+                return "main"
+            if "rev-parse" in cmd:
+                return "abc12345"
+            if "symbolic-ref" in cmd:
+                return "main"
+            return ""
+
+        def fake_check_call(cmd, **kw):
+            if "fetch" in cmd:
+                raise subprocess.CalledProcessError(1, cmd)
+
+        monkeypatch.setattr("subprocess.check_output", fake_check_output)
+        monkeypatch.setattr("subprocess.check_call", fake_check_call)
+
+        result = commands._update_one("geno-dev")
+        assert result.status == "error"
+        assert "fetch" in result.detail
+
+    def test_pull_ff_only_failure(self, fake_skillset, monkeypatch):
+        fake_skillset("geno-dev")
+
+        def fake_check_output(cmd, **kw):
+            if "status" in cmd and "--porcelain" in cmd:
+                return ""
+            if "branch" in cmd and "--show-current" in cmd:
+                return "main"
+            if "rev-parse" in cmd:
+                return "abc12345"
+            if "symbolic-ref" in cmd:
+                return "main"
+            return ""
+
+        def fake_check_call(cmd, **kw):
+            if "pull" in cmd:
+                raise subprocess.CalledProcessError(1, cmd)
+
+        monkeypatch.setattr("subprocess.check_output", fake_check_output)
+        monkeypatch.setattr("subprocess.check_call", fake_check_call)
+
+        result = commands._update_one("geno-dev")
+        assert result.status == "error"
+        assert "diverged" in result.detail
+
+
+# ── _maybe_reinstall_venv ────────────────────────────────────────────────
+
+
+class TestMaybeReinstallVenv:
+    def test_reinstalls_when_pyproject_changed(self, fake_skillset, monkeypatch):
+        fake_skillset("geno-dev", has_pyproject=True)
+        venv_dir = paths.skillset_venvs("geno-dev") / "default"
+        venv_dir.mkdir(parents=True)
+        pip = venv_dir / "bin" / "pip"
+        pip.parent.mkdir(parents=True)
+        pip.write_text("#!/bin/sh\n")
+
+        pip_calls = []
+
+        def fake_check_output(cmd, **kw):
+            if "diff" in cmd and "--name-only" in cmd:
+                return "pyproject.toml\nREADME.md\n"
+            return ""
+
+        def fake_check_call(cmd, **kw):
+            if "pip" in str(cmd[0]):
+                pip_calls.append(cmd)
+
+        monkeypatch.setattr("subprocess.check_output", fake_check_output)
+        monkeypatch.setattr("subprocess.check_call", fake_check_call)
+
+        commands._maybe_reinstall_venv("geno-dev", "old123", "new456")
+        assert len(pip_calls) == 1
+        assert "-e" in pip_calls[0]
+
+    def test_skips_when_pyproject_unchanged(self, fake_skillset, monkeypatch):
+        fake_skillset("geno-dev", has_pyproject=True)
+        pip_calls = []
+
+        def fake_check_output(cmd, **kw):
+            if "diff" in cmd and "--name-only" in cmd:
+                return "README.md\nsrc/main.py\n"
+            return ""
+
+        monkeypatch.setattr("subprocess.check_output", fake_check_output)
+        monkeypatch.setattr("subprocess.check_call",
+                            lambda cmd, **kw: pip_calls.append(cmd))
+
+        commands._maybe_reinstall_venv("geno-dev", "old123", "new456")
+        assert len(pip_calls) == 0
+
+    def test_skips_when_no_pyproject(self, fake_skillset, monkeypatch):
+        fake_skillset("geno-dev")  # no has_pyproject
+        pip_calls = []
+        monkeypatch.setattr("subprocess.check_call",
+                            lambda cmd, **kw: pip_calls.append(cmd))
+
+        commands._maybe_reinstall_venv("geno-dev", "old123", "new456")
+        assert len(pip_calls) == 0
+
+
+# ── _update (top-level) ─────────────────────────────────────────────────
+
+
+class TestUpdateAll:
+    def test_updates_all_installed(self, fake_skillset, monkeypatch, capsys):
+        fake_skillset("geno-agents")
+        fake_skillset("geno-dev")
+        fake_skillset("geno-media")
+
+        def fake_check_output(cmd, **kw):
+            if "status" in cmd and "--porcelain" in cmd:
+                return ""
+            if "branch" in cmd and "--show-current" in cmd:
+                return "main"
+            if "rev-parse" in cmd:
+                return "same1234"
+            if "symbolic-ref" in cmd:
+                return "main"
+            return ""
+
+        monkeypatch.setattr("subprocess.check_output", fake_check_output)
+        monkeypatch.setattr("subprocess.check_call", lambda cmd, **kw: None)
+
+        from genotools.cli import main
+        rc = main(["update"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "geno-agents" in out
+        assert "geno-dev" in out
+        assert "geno-media" in out
+
+    def test_excludes_bootstrap(self, tmp_root, monkeypatch, capsys):
+        (tmp_root / "geno-bootstrap").mkdir()
+        from genotools.cli import main
+        rc = main(["update"])
+        assert rc == 0
+        assert "no skillsets" in capsys.readouterr().out
+
+    def test_empty_install(self, tmp_root, capsys):
+        from genotools.cli import main
+        rc = main(["update"])
+        assert rc == 0
+        assert "no skillsets" in capsys.readouterr().out
+
+
+class TestUpdateCli:
+    def test_single_by_name(self, fake_skillset, monkeypatch, capsys):
+        fake_skillset("geno-dev")
+
+        def fake_check_output(cmd, **kw):
+            if "status" in cmd and "--porcelain" in cmd:
+                return ""
+            if "branch" in cmd and "--show-current" in cmd:
+                return "main"
+            if "rev-parse" in cmd:
+                return "same1234"
+            if "symbolic-ref" in cmd:
+                return "main"
+            return ""
+
+        monkeypatch.setattr("subprocess.check_output", fake_check_output)
+        monkeypatch.setattr("subprocess.check_call", lambda cmd, **kw: None)
+
+        from genotools.cli import main
+        rc = main(["update", "geno-dev"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "geno-dev" in out
+
+    def test_nonexistent_fails(self, tmp_root, capsys):
+        from genotools.cli import main
+        rc = main(["update", "geno-nonexistent"])
+        assert rc == 1
+        assert "not installed" in capsys.readouterr().err
+
+    def test_bare_slug_accepted(self, fake_skillset, monkeypatch, capsys):
+        fake_skillset("geno-dev")
+
+        def fake_check_output(cmd, **kw):
+            if "status" in cmd and "--porcelain" in cmd:
+                return ""
+            if "branch" in cmd and "--show-current" in cmd:
+                return "main"
+            if "rev-parse" in cmd:
+                return "same1234"
+            if "symbolic-ref" in cmd:
+                return "main"
+            return ""
+
+        monkeypatch.setattr("subprocess.check_output", fake_check_output)
+        monkeypatch.setattr("subprocess.check_call", lambda cmd, **kw: None)
+
+        from genotools.cli import main
+        rc = main(["update", "dev"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "geno-dev" in out
+
+
+# ── summary output ───────────────────────────────────────────────────────
+
+
+class TestPrintUpdateSummary:
+    def test_shows_all_categories(self, capsys):
+        results = [
+            commands._UpdateResult("geno-a", "updated", old_rev="aaa", new_rev="bbb"),
+            commands._UpdateResult("geno-b", "up-to-date"),
+            commands._UpdateResult("geno-c", "skipped", detail="dirty worktree"),
+            commands._UpdateResult("geno-d", "error", detail="git fetch failed"),
+        ]
+        commands._print_update_summary(results)
+        out = capsys.readouterr().out
+        assert "updated (1)" in out
+        assert "up-to-date (1)" in out
+        assert "skipped (1)" in out
+        assert "errors (1)" in out
+        assert "geno-a" in out
+        assert "aaa -> bbb" in out
+        assert "dirty worktree" in out
+        assert "git fetch failed" in out
+
+    def test_omits_empty_categories(self, capsys):
+        results = [
+            commands._UpdateResult("geno-a", "up-to-date"),
+        ]
+        commands._print_update_summary(results)
+        out = capsys.readouterr().out
+        assert "updated" not in out
+        assert "skipped" not in out
+        assert "errors" not in out
+        assert "up-to-date (1)" in out


### PR DESCRIPTION
## Summary
- Replaces the `_update` stub in `commands.py` with a full implementation that fetches origin, fast-forwards the main worktree, reinstalls venvs when `pyproject.toml` changes, and re-registers skills via `npx skills add`
- Adds `skills/geno-tools-update/SKILL.md` sub-skill following the skillset naming convention
- Adds an **Ecosystem Freshness** audit section to `geno-audit` for checking whether installed skillsets are up-to-date
- 19 new tests in `tests/test_update.py` covering all update paths (up-to-date, updated, dirty worktree, wrong branch, dev mode, fetch/pull failures, venv reinstall)

## Test plan
- [x] `pytest tests/test_update.py -v` — 19/19 pass
- [x] `pytest tests/` — 135/136 pass (1 pre-existing failure in `test_plugin.py`)
- [x] `geno-tools update geno-dev` — fetches and reports up-to-date
- [x] `geno-tools update` — updates all 8 installed skillsets, prints grouped summary
- [x] `npx skills add` — `geno-tools-update` skill installs and registers across all agents