### PR TITLE
Add versioning policy for skillset repos

### DIFF
--- a/docs/onboarding/audit.md
+++ b/docs/onboarding/audit.md
@@ -7,11 +7,11 @@ A skillset is allowed to inject prompts into the agent's context, run shell comm
 ## When to run the audit
 
 - **Initial onboarding** — first inclusion in the registry (public) or internal mirror (enterprise).
-- **Major version bump** — any release that changes `SKILL.md` content, adds slash commands, changes `pyproject.toml` dependencies, or modifies runtime symlinks.
+- **Major or minor version bump** — any release that adds or removes skills, changes `SKILL.md` prompt content, adds slash commands, changes `pyproject.toml` dependencies, or modifies runtime symlinks. See [Versioning](../skillsets/creating.md#versioning) for what constitutes each bump level.
 - **Maintainer change** — when ownership transfers to a new author.
 - **Periodic re-audit** — every 6 months for high-traffic skillsets, opportunistically for the rest.
 
-A patch-level update that only touches docs or already-audited prompt content does not require a full re-audit.
+A patch-level update (bug fixes, doc-only changes, wording improvements) does not require a full re-audit — use the [lightweight re-audit](#lightweight-re-audit) instead.
 
 ## How to run it
 

--- a/docs/skillsets/creating.md
+++ b/docs/skillsets/creating.md
@@ -83,6 +83,31 @@ Copy-once files into `~/.geno-tools/geno-{name}/configs/`. Only created if missi
 | `src` | Path relative to repo root |
 | `dst` | Path relative to configs dir |
 
+## Versioning
+
+The `version` field in `genotools.yaml` is the canonical version for every skillset. If other files also carry a version — `pyproject.toml` (`project.version`), `package.json` (`version`), or a Python `__init__.py` (`__version__`) — they must all match. When bumping, update `genotools.yaml` first, then sync the rest.
+
+### What to bump
+
+| Change type | Bump | Examples |
+|-------------|------|----------|
+| Bug fix, typo, wording improvement in skill instructions | PATCH (0.0.x) | Fix broken bash snippet in SKILL.md, clarify ambiguous instruction |
+| Doc-only changes with no behavior impact | PATCH | Update getting-started.md, add architecture doc |
+| New skill added | MINOR (0.x.0) | Add `geno-{name}-reports-generate` skill |
+| Existing skill behavior significantly expanded | MINOR | Add new workflow steps to an existing skill |
+| New config options, runtime scripts, or dependencies | MINOR | Add a `runtime:` entry, add a pip dep to `venv.deps` |
+| Removed skill or slash command | MAJOR (x.0.0) | Delete a `skills/` directory |
+| Renamed slash command | MAJOR | Change a skill's `name` field |
+| Incompatible manifest changes | MAJOR | Restructure `genotools.yaml` format |
+
+### When NOT to bump
+
+Not every commit needs a version bump. If you're making a series of related changes on a branch before merging, bump once in the final commit of the series. The version in `main` should always reflect the latest released state.
+
+### What GENO.md should say
+
+Individual repos must not restate the full versioning policy — that lives here in geno-tools. Instead, their `GENO.md` Conventions section should include a brief **Versioning** item that tells agents: (1) the canonical version lives in `genotools.yaml`, (2) which other files (if any) also contain versions and must stay in sync, and (3) to bump the version when adding/removing skills or changing behavior.
+
 ## Skills — `skills/`
 
 Skills are defined as `SKILL.md` files under `skills/`. Each skill lives in its own directory. The directory name must match the `name` field in the SKILL.md frontmatter.
@@ -141,6 +166,7 @@ The root `SKILL.md` at the repo root is the umbrella manifest. It describes the 
     - SKILL.md frontmatter format
     - Checklist for adding a new skill
     - Command prefix aliasing (see below)
+    - Versioning: which files contain the version and when to bump (see [Versioning](#versioning))
 
 ### Per-agent pointer files
 

--- a/skills/geno-audit/SKILL.md
+++ b/skills/geno-audit/SKILL.md
@@ -95,6 +95,26 @@ The local `.geno/` directory at the repo or workspace root holds per-workspace s
 
 ---
 
+## Versioning
+
+The `version` field in `genotools.yaml` is the canonical version for every skillset. When a repo also has `pyproject.toml`, `package.json`, or a Python `__init__.py` with version fields, they must all agree. The audit checks consistency and detects unreleased work that may warrant a bump.
+
+### Audit checks
+
+**Required:**
+- `genotools.yaml` `version` is a valid semver string (MAJOR.MINOR.PATCH)
+
+**Recommended:**
+- If `pyproject.toml` exists and has `project.version`, it matches `genotools.yaml` version
+- If `package.json` exists and has `version`, it matches `genotools.yaml` version
+- If root `SKILL.md` has `metadata.version` in frontmatter, it matches `genotools.yaml` version
+- If a Python `__init__.py` in the package root has `__version__`, it matches `genotools.yaml` version
+
+**Info:**
+- If skills have been added or removed since the last git tag (compare `skills/` directories against the most recent tag), note that a version bump may be warranted
+
+---
+
 ## Umbrella Skill — `SKILL.md`
 
 `SKILL.md` at the repo root is the umbrella manifest that describes the skillset to Claude Code and other agents. When `geno-tools install` runs `npx skills add`, this file is what gets registered — it tells the agent what the skillset does, when to use it, and what tools it's allowed to call. A skillset without a valid `SKILL.md` will install on disk but won't be usable by any agent.
@@ -198,6 +218,7 @@ Rather than maintaining duplicate content across `CLAUDE.md`, `GEMINI.md`, `AGEN
    - **SKILL.md frontmatter**: required fields and format for new skills
    - **Adding a new skill**: step-by-step checklist (create directory under `skills/`, write SKILL.md with frontmatter, update umbrella description, update docs, update this file's skills table)
    - **Command prefix aliasing**: slash commands in repo source files must always use the canonical `geno-` prefix (e.g. `/geno-{name}-tasks-start`). The prefix users type (`/gt-`, `/geno-`, or bare `/`) is configured per-installation in `~/.geno/config.yaml` and applied at install time by `geno-tools install`. Never hardcode an aliased prefix like `gt-` in SKILL.md descriptions, GENO.md, or any committed file.
+   - **Versioning**: which files contain the version number (always `genotools.yaml`; plus any others like `pyproject.toml` or `package.json`) and the rule that the version must be bumped when adding/removing skills or changing behavior
 
 #### Recommended sections
 
@@ -257,6 +278,7 @@ This way, updating `GENO.md` updates every agent at once. No content lives in th
 - `GENO.md` Conventions section mentions command prefix aliasing — at minimum, states that source files use canonical `geno-` prefixed names for slash commands, not aliased prefixes
 - `GENO.md` Conventions section includes skill creation guidance — at minimum, a checklist for adding a new skill
 - `GENO.md` skills table uses canonical `/geno-{name}-*` slash command names, not aliased forms like `/gt-*`
+- `GENO.md` Conventions section includes versioning guidance — at minimum, identifies which files contain the version and states that the version should be bumped when skills are added, removed, or behavior changes
 
 ---
 


### PR DESCRIPTION
## Summary

- Add a **Versioning** section to `docs/skillsets/creating.md` defining when to bump PATCH/MINOR/MAJOR, which files carry the version, and what GENO.md should say about it
- Add **Versioning** audit checks to `skills/geno-audit/SKILL.md` — validates semver format, cross-file version consistency, and detects unreleased skill changes
- Update `docs/onboarding/audit.md` re-audit triggers to reference the new policy

## Test plan

- [ ] Verify `mkdocs serve` renders the new Versioning section in the skillsets docs
- [ ] Run `geno-audit` against a skillset repo and confirm versioning checks appear in the report
- [ ] Verify cross-reference links resolve (audit.md → creating.md#versioning, creating.md internal anchors)