### PR TITLE
Add geno-alias skill for custom slash-command aliases

### DIFF
--- a/GENO.md
+++ b/GENO.md
@@ -7,6 +7,7 @@
 | Skill | Sub-skillset | Slash command |
 |-------|-------------|---------------|
 | geno-tools | — | — (umbrella) |
+| geno-alias | — | /geno-alias |
 | geno-audit | — | /geno-audit |
 | geno-icons | — | /geno-icons |
 | geno-onboarding | — | /geno-onboarding |
@@ -39,6 +40,7 @@ geno-tools/
 │   └── registry.py                #   curated registry of known skillsets
 ├── skills/                        # skill definitions
 │   ├── geno-tools/SKILL.md        #   umbrella skill
+│   ├── geno-alias/SKILL.md        #   custom skill aliasing
 │   ├── geno-audit/SKILL.md        #   ecosystem compliance auditor
 │   ├── geno-icons/SKILL.md        #   pixel art icon generator
 │   ├── geno-onboarding/SKILL.md   #   skillset onboarding wizard

--- a/skills/geno-alias/SKILL.md
+++ b/skills/geno-alias/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: geno-alias
+description: >-
+  Create, remove, and list custom slash-command aliases for geno ecosystem
+  skills. Use when user says /geno-alias or wants to create a shortcut,
+  alias, or abbreviation for an existing skill.
+allowed-tools: "Bash(mkdir *) Bash(rm *) Bash(cp *) Bash(cat *) Bash(ls *) Bash(npx *) Bash(python3 *) Bash(test *) Bash(find *) Bash(grep *) Bash(sed *) Read Write Edit"
+argument-hint: "[add|remove|list] [source-skill] [alias-name]"
+license: MIT
+metadata:
+  author: 42euge
+  version: "0.1.0"
+---
+
+# geno-alias — Skill Aliasing
+
+Create custom slash-command aliases for any installed geno ecosystem skill. Aliases are tracked in `~/.geno/.genorc` and registered with all agents via `npx skills`.
+
+## Argument parsing
+
+Parse `$ARGUMENTS` into one of three operations:
+
+| Input | Operation |
+|-------|-----------|
+| `list` or empty | List all aliases |
+| `remove <alias>` | Remove an alias |
+| `add <source> <alias>` | Create an alias |
+| `<source> <alias>` (two args, first is not `add`/`remove`/`list`) | Create an alias (shorthand) |
+
+Strip leading `/` from both source and alias names.
+
+## Add operation
+
+### Step 1 — Validate source skill exists
+
+```bash
+SOURCE="<source>"
+if [ -f "$HOME/.agents/skills/$SOURCE/SKILL.md" ]; then
+  SRC_PATH="$HOME/.agents/skills/$SOURCE/SKILL.md"
+elif [ -f "$HOME/.claude/skills/$SOURCE/SKILL.md" ]; then
+  SRC_PATH="$HOME/.claude/skills/$SOURCE/SKILL.md"
+else
+  echo "Source skill '$SOURCE' not found."
+  echo "Available skills:"
+  ls ~/.agents/skills/ 2>/dev/null; ls ~/.claude/skills/ 2>/dev/null
+  exit 1
+fi
+```
+
+### Step 2 — Validate alias doesn't shadow a non-alias skill
+
+Check `~/.geno/.genorc` — if the alias name already exists there, it's a previously created alias and can be overwritten. If it exists in `~/.agents/skills/` or `~/.claude/skills/` but is NOT in `.genorc`, warn that creating this alias would shadow an existing skill and ask the user to confirm.
+
+### Step 3 — Create the alias SKILL.md
+
+Read the source SKILL.md. Create a copy with the `name:` field **removed** from the frontmatter (so `npx skills` derives the name from the directory). All other frontmatter and body content are preserved unchanged.
+
+```bash
+mkdir -p "$HOME/.geno/aliases/ALIAS_NAME"
+```
+
+Use `python3` to strip the `name:` field:
+
+```bash
+python3 -c "
+import re, sys
+content = open(sys.argv[1]).read()
+parts = content.split('---', 2)
+if len(parts) >= 3:
+    fm = re.sub(r'^name:.*\n', '', parts[1], flags=re.MULTILINE)
+    result = '---' + fm + '---' + parts[2]
+else:
+    result = content
+open(sys.argv[2], 'w').write(result)
+" "$SRC_PATH" "$HOME/.geno/aliases/ALIAS_NAME/SKILL.md"
+```
+
+### Step 4 — Register with npx skills
+
+```bash
+npx --yes skills add "$HOME/.geno/aliases/ALIAS_NAME" --agent "*" --global --yes
+```
+
+### Step 5 — Record in .genorc
+
+```bash
+python3 -c "
+import sys
+from pathlib import Path
+
+rc = Path.home() / '.geno' / '.genorc'
+# Read existing content or start fresh
+lines = rc.read_text().splitlines() if rc.exists() else []
+
+# Ensure 'aliases:' header exists
+if not any(l.strip() == 'aliases:' for l in lines):
+    lines.append('aliases:')
+
+# Remove any existing entry for this alias
+alias, source = sys.argv[1], sys.argv[2]
+lines = [l for l in lines if not l.strip().startswith(alias + ':')]
+
+# Find the aliases: line and insert after it
+idx = next(i for i, l in enumerate(lines) if l.strip() == 'aliases:')
+lines.insert(idx + 1, f'  {alias}: {source}')
+
+rc.write_text('\n'.join(lines) + '\n')
+" "ALIAS_NAME" "SOURCE"
+```
+
+### Step 6 — Report
+
+Tell the user the alias was created. Note that it will take effect in the **next session** (since Claude Code loads skills at session start).
+
+## Remove operation
+
+### Step 1 — Look up alias in .genorc
+
+```bash
+python3 -c "
+import sys, re
+from pathlib import Path
+rc = Path.home() / '.geno' / '.genorc'
+if not rc.exists():
+    print('No aliases configured.'); sys.exit(1)
+content = rc.read_text()
+alias = sys.argv[1]
+m = re.search(rf'^\s+{re.escape(alias)}:\s+(.+)$', content, re.MULTILINE)
+if not m:
+    print(f\"'{alias}' is not a registered alias.\"); sys.exit(1)
+print(m.group(1).strip())
+" "ALIAS_NAME"
+```
+
+If not found, report that the alias doesn't exist and show available aliases.
+
+### Step 2 — Unregister
+
+```bash
+npx --yes skills remove "ALIAS_NAME" --agent "*" --global --yes
+```
+
+### Step 3 — Clean up files
+
+```bash
+rm -rf "$HOME/.geno/aliases/ALIAS_NAME"
+```
+
+### Step 4 — Remove from .genorc
+
+```bash
+python3 -c "
+import re, sys
+from pathlib import Path
+rc = Path.home() / '.geno' / '.genorc'
+content = rc.read_text()
+alias = sys.argv[1]
+content = re.sub(rf'^\s+{re.escape(alias)}:.*\n', '', content, flags=re.MULTILINE)
+# Remove 'aliases:' header if no entries remain
+if re.search(r'^aliases:\s*$', content, re.MULTILINE) and not re.search(r'^  \w', content, re.MULTILINE):
+    content = re.sub(r'^aliases:\s*\n', '', content, flags=re.MULTILINE)
+content = content.strip()
+if content:
+    rc.write_text(content + '\n')
+else:
+    rc.unlink()
+" "ALIAS_NAME"
+```
+
+### Step 5 — Report
+
+Tell the user the alias was removed and will disappear next session.
+
+## List operation
+
+```bash
+python3 -c "
+from pathlib import Path
+import re
+rc = Path.home() / '.geno' / '.genorc'
+if not rc.exists():
+    print('No aliases configured.'); raise SystemExit
+content = rc.read_text()
+entries = re.findall(r'^\s+(\S+):\s+(\S+)', content, re.MULTILINE)
+if not entries:
+    print('No aliases configured.'); raise SystemExit
+print(f'{len(entries)} alias(es):\n')
+for alias, source in sorted(entries):
+    installed = 'installed' if (Path.home() / '.claude/skills' / alias).exists() else 'not installed'
+    print(f'  /{alias}  ->  /{source}  ({installed})')
+"
+```

--- a/skills/geno-tools/SKILL.md
+++ b/skills/geno-tools/SKILL.md
@@ -31,6 +31,7 @@ Install by full repo name (e.g. `geno-tools install geno-<name>`):
 
 | Skill | Description |
 |-------|-------------|
+| geno-alias | Create, remove, and list custom slash-command aliases |
 | geno-data-workspaces-init | Create data workspaces for personal/life skills (taxes, remodel, career) |
 | geno-skills-create | Scaffold a new skill in a geno ecosystem repo |
 | geno-skills-install | Install skills from a local repo checkout globally |


### PR DESCRIPTION
## Summary
- Adds `geno-alias` skill that creates, removes, and lists arbitrary slash-command aliases for any installed geno ecosystem skill
- Aliases are stored as SKILL.md copies in `~/.geno/aliases/<name>/` and registered via `npx skills add`
- Mappings tracked in `~/.geno/.genorc` (YAML)
- Complements the existing prefix-based aliasing (`geno-*` → `gt-*`) with per-skill granularity

## Usage
```
/geno-alias geno-skills-status gt-status    # create alias
/geno-alias remove gt-status                # remove alias
/geno-alias list                            # show all aliases
```

## Test plan
- [ ] Invoke `/geno-alias list` — should report "No aliases configured"
- [ ] Invoke `/geno-alias geno-skills-status gt-status` — should create alias dir in `~/.geno/aliases/gt-status/`, register with npx skills, and update `.genorc`
- [ ] Verify `~/.geno/.genorc` contains the mapping
- [ ] Invoke `/geno-alias list` — should show the new alias
- [ ] Invoke `/geno-alias remove gt-status` — should clean up alias dir, unregister, and remove from `.genorc`