### PR TITLE
Add VISION.md and TENETS.md, reframe docs around skill lifecycle

### DIFF
--- a/GENO.md
+++ b/GENO.md
@@ -1,6 +1,9 @@
-# geno-tools — Skillset Manager for the Geno Ecosystem
+# geno-tools — Agent-Agnostic Meta Package Manager for AI Coding Agents
 
-`geno-tools` is a meta-CLI and coding-agent plugin that installs sibling `geno-{name}` repos as coding agent skillsets. It handles cloning, venvs, bin symlinks, dependency resolution, and skill registration across all supported agents (Claude Code, Gemini CLI, Codex, OpenCode, Cursor).
+`geno-tools` is an agent-agnostic meta package manager for AI coding agents. It discovers skills from open-source and private ecosystems, absorbs external skill systems (Vercel Labs Skills, Superpowers, Ralphy Loop plugins) into a unified framework, and manages their lifecycle across all supported agents (Claude Code, Gemini CLI, Codex, OpenCode, Cursor). A meta-harness layer evaluates and refines skill variations over time, while built-in auditing ensures capabilities evolve safely.
+
+@./VISION.md
+@./TENETS.md
 
 ## Skills
 
@@ -173,3 +176,5 @@ geno-{name}/
 geno-tools ships platform-specific plugin manifests following the `obra/superpowers` conventions so it can be installed as a native plugin on each supported CLI. Skills are platform-agnostic; each CLI-specific manifest points at the shared `skills/` directory.
 
 Skill registration uses `npx skills add <active-worktree> --agent '*' --global --skill '*' --yes`. Uninstall enumerates skills (root SKILL.md + `skills/*/SKILL.md`) and calls `npx skills remove`.
+
+This absorption layer is what makes geno-tools a meta-harness rather than just a CLI — external skill systems (Superpowers conventions, Vercel Labs Skills backend) are normalized into the same `SKILL.md` + `genotools.yaml` contract.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # geno-tools
 
-Meta-CLI for installing and managing coding agent skillsets in the `geno-*` ecosystem. Works with Claude Code, Codex, Gemini CLI, Cursor, and OpenCode.
+Agent-agnostic meta package manager for AI coding agents. Discovers, absorbs, evaluates, and governs skills across Claude Code, Codex, Gemini CLI, Cursor, and OpenCode.
 
 **Website:** <https://42euge.github.io/geno-tools>
 
 ## What it does
 
-`geno-tools` installs/uninstalls/dev-links curated skillset repos (each a `geno-{name}` repo) into any supported coding agent. Inspired by [vercel-labs/skills](https://github.com/vercel-labs/skills) and [obra/superpowers](https://github.com/obra/superpowers), specialized for this ecosystem:
+`geno-tools` discovers skills from open-source registries and private ecosystems, absorbs external skill systems ([vercel-labs/skills](https://github.com/vercel-labs/skills), [obra/superpowers](https://github.com/obra/superpowers), Ralphy Loop plugins) into a unified framework, and manages their full lifecycle:
 
-- **Curated registry** — full repo names (`geno-<name>`, e.g. those listed below) resolve to git URLs
-- **Multi-agent** — skills register with all agents via `npx skills add --agent '*'`
+- **Discovery** — find candidate skills from a curated registry, GitHub/GitLab/Bitbucket orgs, private mirrors, or any git URL
+- **Absorption** — normalize heterogeneous skill formats into `SKILL.md` + `genotools.yaml`; register with all agents via a single `geno-tools install`
+- **Meta-harness** — `fork`/`use`/`promote` with git worktrees to evaluate, refine, and iterate on skill variations in isolation
+- **Auditing** — built-in compliance scanning gates every onboarding path (prompt injection, dependency hygiene, filesystem/network boundaries)
 - **Per-skillset venvs** — isolated at `~/.geno-tools/geno-{name}/venvs/`
-- **Dev-link** — point at a local checkout for meta-improvement
+- **Zero telemetry** — local execution, no call-home
 
 ## Install
 

--- a/TENETS.md
+++ b/TENETS.md
@@ -1,0 +1,17 @@
+# Tenets
+
+Architectural principles that guide all development decisions in geno-tools. When tenets conflict, earlier entries take precedence.
+
+1. **Agent-agnostic** — geno-tools is a package manager that targets all coding agents through platform-specific adapters. It is not a CLI for one agent. Every feature must work across Claude Code, Codex, Gemini CLI, Cursor, and OpenCode.
+
+2. **Skill-system absorption** — external skill formats (Vercel Labs Skills, Superpowers, Ralphy Loop) are first-class import sources, not just inspiration. The plugin structure normalizes them into the `SKILL.md` + `genotools.yaml` contract so skills from any origin are managed the same way.
+
+3. **Auditing as infrastructure** — compliance scanning gates every onboarding path: public registry, enterprise namespace, and direct URL. It is not an optional add-on. New ingestion paths must integrate with the audit checklist before shipping.
+
+4. **Lifecycle-driven** — every skill follows discover, absorb, evaluate, govern, evolve. The tooling enforces it. Features that bypass or shortcut the lifecycle need explicit justification.
+
+5. **Local-first, zero telemetry** — all execution is local. No call-home, no usage tracking, no analytics. Private knowledge stays inside the boundary of the machine or organization that owns it.
+
+6. **Isolated by default** — per-skillset venvs, git worktrees for variants, nothing leaks between skillsets. A failure or compromise in one skillset must not affect another.
+
+7. **Exact removal** — uninstall replays install in reverse. No orphaned files, no stale symlinks, no leftover agent registrations. `geno-tools remove` must leave the system as if the skill was never installed.

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,27 @@
+# Vision
+
+geno-tools is an agent-agnostic meta package manager for AI coding agents. It discovers skills from both open-source and internal ecosystems and can absorb external skill systems (e.g., Superpowers, Ralphy Loop plugins) into a unified framework. A meta-harness layer evaluates, refines, and manages variations of these skills over time, while built-in auditing scans the ecosystem for compliance, allowing capabilities to evolve safely by combining external innovation with private knowledge.
+
+## Core loop
+
+```
+discover ──→ absorb ──→ evaluate ──→ govern ──→ evolve
+    │            │           │           │          │
+discovery.py  install    fork/use     geno-audit  promote
+registry.py   npx skills  worktrees   audit.md    merge → main
+config.yaml   normalize
+```
+
+**Discover** — find candidate skills from heterogeneous sources: the curated registry (`registry.py`), GitHub/GitLab/Bitbucket orgs via config-driven discovery (`discovery.py`), private mirrors, or direct git URLs.
+
+**Absorb** — normalize external skill systems into the unified `SKILL.md` + `genotools.yaml` contract. `geno-tools install` is the single ingestion point regardless of whether a skill originates from Vercel Labs Skills, obra/superpowers, Ralphy Loop, or a private internal repo.
+
+**Evaluate** — the meta-harness. `fork`/`use`/`promote` with git worktrees lets operators branch a skill, experiment in isolation, and iterate without touching the primary install. Multiple variations can coexist; the best is promoted.
+
+**Govern** — built-in auditing (`geno-audit`) scans skills for compliance before they enter any namespace. The audit checklist covers prompt injection, dependency hygiene, filesystem boundaries, network data boundaries, and multi-agent integration. Every ingestion path — public registry PRs, enterprise namespace admissions, direct-URL installs — passes through this gate.
+
+**Evolve** — promote successful variants back to main; discard failures. Combine external innovation with private knowledge to produce skills that improve over time. The loop repeats: a promoted skill can be forked again, re-evaluated, re-audited.
+
+## Why this matters
+
+Agents self-improve by acquiring new skills at runtime. The meta-harness ensures those skills are tested and refined before they become defaults. Auditing ensures they are safe. The result is an ecosystem of capabilities that evolves continuously — absorbing the best of the open-source community while keeping proprietary knowledge private and compliant.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,6 +1,18 @@
 # Architecture
 
-geno-tools is structured around a few core concepts:
+geno-tools is an agent-agnostic meta package manager structured around a five-phase skill lifecycle: **discover, absorb, evaluate, govern, evolve**. This page covers the core architectural components that implement that lifecycle.
+
+## Skill lifecycle
+
+```
+discover ──→ absorb ──→ evaluate ──→ govern ──→ evolve
+    │            │           │           │          │
+discovery.py  install    fork/use     geno-audit  promote
+registry.py   npx skills  worktrees   audit.md    merge → main
+config.yaml   normalize
+```
+
+Discovery finds candidates from heterogeneous sources (public registries, private GitHub/GitLab/Bitbucket orgs, direct URLs). Absorption normalizes them via `geno-tools install` into the `SKILL.md` + `genotools.yaml` contract. Evaluation uses the variant worktree system (`fork`/`use`/`promote`) to experiment in isolation. Governance runs the audit checklist before skills enter any namespace. Evolution promotes successful variants back to main, and the loop repeats.
 
 ## Multi-agent installation
 
@@ -79,6 +91,18 @@ geno-tools/
 ```
 
 Skills and commands are shared across all platforms. Each CLI has its own manifest that points at these shared directories.
+
+## Meta-harness
+
+The `fork`/`use`/`promote` workflow documented in [Variants & Worktrees](variants.md) constitutes the meta-harness: a system that drives evaluation and iteration of skills over time. Operators branch a skill into an isolated worktree, test modifications against real workloads, and promote the winner back to main. Multiple variations can coexist — the meta-harness manages the state so the active variant is always explicit.
+
+Combined with auditing, the meta-harness enables skills to evolve safely: experiment freely in isolation, but nothing reaches the default install path without passing the compliance gate.
+
+## Auditing
+
+Auditing is a core architectural pillar, not an optional add-on. Every skill that enters the ecosystem — whether from the public registry, an enterprise namespace, or a direct URL — passes through the compliance gate. The `geno-audit` skill and the [audit checklist](../onboarding/audit.md) cover prompt injection, dependency hygiene, filesystem boundaries, network data boundaries, and multi-agent integration.
+
+New ingestion paths must integrate with the audit system before shipping. See the [Audit Process](../onboarding/audit.md) for the full specification.
 
 ## Pages
 

--- a/docs/docs-home.md
+++ b/docs/docs-home.md
@@ -2,8 +2,8 @@
 
 # geno-<span>tools</span>
 
-The package manager for AI coding agent skillsets.
-Install, fork, experiment, promote — as a native plugin in your coding agent.
+The agent-agnostic meta package manager for AI coding agents.
+Discover, absorb, evaluate, govern, evolve — as a native plugin in any coding agent.
 
 <div class="hero-buttons">
 <a href="getting-started/" class="btn-primary">Get Started</a>
@@ -15,43 +15,53 @@ Install, fork, experiment, promote — as a native plugin in your coding agent.
 <div class="feature-grid" markdown>
 
 <div class="feature-card" markdown>
-<span class="card-icon">:material-download:</span>
+<span class="card-icon">:material-magnify:</span>
 
-### Install in seconds
+### Discover
 
-Install as a Claude Code plugin or its equivalent on Codex, Cursor, Gemini CLI, or OpenCode. Short names resolve from a curated registry.
+Find skills from open-source registries, private GitHub/GitLab orgs, or any git remote.
 
 [Get started :material-arrow-right:](getting-started.md)
 </div>
 
 <div class="feature-card" markdown>
-<span class="card-icon">:material-console:</span>
+<span class="card-icon">:material-download:</span>
 
-### Full CLI
+### Absorb
 
-`ls`, `install`, `dev`, `fork`, `use`, `promote`, `update`, `remove`, `doctor` — everything you need.
+Normalize external skill systems (Superpowers, Vercel Skills, Ralphy Loop) into a unified framework.
 
-[CLI Reference :material-arrow-right:](cli-reference.md)
-</div>
-
-<div class="feature-card" markdown>
-<span class="card-icon">:material-puzzle:</span>
-
-### Skillset ecosystem
-
-Media, research, kaggle, agents — each a self-contained repo with a declarative manifest.
-
-[Browse skillsets :material-arrow-right:](skillsets/index.md)
+[Architecture :material-arrow-right:](architecture/index.md)
 </div>
 
 <div class="feature-card" markdown>
 <span class="card-icon">:material-source-branch:</span>
 
-### Variant worktrees
+### Evaluate
 
-Fork a skillset, experiment in isolation, promote back to main. Git worktrees under the hood.
+Fork a skill, experiment in isolation, promote back to main. Git worktrees power the meta-harness.
 
-[Learn more :material-arrow-right:](architecture/variants.md)
+[Variants :material-arrow-right:](architecture/variants.md)
+</div>
+
+<div class="feature-card" markdown>
+<span class="card-icon">:material-shield-check:</span>
+
+### Govern
+
+Built-in auditing scans for compliance — prompt injection, dependency hygiene, data boundaries.
+
+[Audit process :material-arrow-right:](onboarding/audit.md)
+</div>
+
+<div class="feature-card" markdown>
+<span class="card-icon">:material-puzzle:</span>
+
+### Evolve
+
+Compose skills across agents, combine external innovation with private knowledge.
+
+[Ecosystem :material-arrow-right:](ecosystem.md)
 </div>
 
 </div>
@@ -101,3 +111,6 @@ Fork a skillset, experiment in isolation, promote back to main. Git worktrees un
 
 :material-puzzle-outline: **Agent-agnostic**
 :   Target adapters for Claude Code, geno-cli, Codex, and Gemini CLI.
+
+:material-sync: **Lifecycle-driven**
+:   Every skill follows discover, absorb, evaluate, govern, evolve. The tooling enforces it.

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -1,6 +1,6 @@
 # Ecosystem
 
-The geno-\* ecosystem is a collection of repos that extend AI coding agents with specialized capabilities. geno-tools is the package manager; each skill is its own repo.
+The geno-\* ecosystem is a collection of repos that extend AI coding agents with specialized capabilities. geno-tools is the agent-agnostic meta package manager at the center: it discovers skills, absorbs external skill systems, evaluates variants via the meta-harness, governs compliance through auditing, and lets capabilities evolve safely.
 
 ## Repos
 
@@ -36,21 +36,39 @@ The geno-\* ecosystem is a collection of repos that extend AI coding agents with
 ## How it fits together
 
 ```
-                    geno-tools (package manager)
-                         │
-          ┌──────────────┼──────────────┐
-          │              │              │
-     geno-<name>   geno-<name>   geno-<name>  ...   (skillsets)
-          │              │              │
-          └──────────────┼──────────────┘
-                         │
-                   Coding CLIs
-                   (Claude Code, geno-cli, Codex, Gemini CLI)
-                         │
-                    geno-agents (coordination)
-                    geno-msg    (messaging)
-                    geno-notes  (project state)
-                    geno-mon    (monitoring)
+              ┌──────────────────────────────────────┐
+              │          geno-tools                   │
+              │    (meta package manager)             │
+              └──────────────┬───────────────────────-┘
+                             │
+        discover ──→ absorb ──→ evaluate ──→ govern ──→ evolve
+           │            │          │            │          │
+      registry.py    install    fork/use    geno-audit  promote
+      discovery.py   normalize  worktrees   audit.md    merge → main
+                             │
+              ┌──────────────┼──────────────┐
+              │              │              │
+         geno-<name>   geno-<name>   geno-<name>  ...
+              │              │              │
+              └──────────────┼──────────────┘
+                             │
+                       Coding CLIs
+           (Claude Code, Codex, Gemini CLI, Cursor, OpenCode)
+                             │
+                  geno-agents (coordination)
+                  geno-msg    (messaging)
+                  geno-notes  (project state)
+                  geno-mon    (monitoring)
 ```
 
 Each skillset is independent — install only what you need. The coordination layer (agents, msg, notes, mon) is optional but enables multi-agent workflows.
+
+## External skill systems
+
+geno-tools absorbs skills from external systems into the unified `SKILL.md` + `genotools.yaml` framework:
+
+- **[Vercel Labs Skills](https://github.com/vercel-labs/skills)** — the backend skill registration layer; `npx skills add` registers skills with all agents
+- **[obra/superpowers](https://github.com/obra/superpowers)** — plugin manifest conventions that geno-tools follows for cross-agent compatibility
+- **Ralphy Loop** — external plugin ecosystem whose skills can be ingested and normalized through `geno-tools install`
+
+Skills from any of these origins are managed the same way once absorbed: same install path, same variant system, same audit checklist, same removal contract.

--- a/docs/onboarding/audit.md
+++ b/docs/onboarding/audit.md
@@ -1,5 +1,7 @@
 # Audit Process
 
+Auditing is a core architectural pillar of geno-tools, not an optional add-on. Every skill that enters the ecosystem — whether from the public registry, an enterprise namespace, or a direct URL — passes through this compliance gate. The audit enforces the **govern** phase of the skill lifecycle (discover, absorb, evaluate, **govern**, evolve).
+
 The audit checklist. Run it before approving a skillset for the public registry, and before admitting one to an enterprise namespace.
 
 A skillset is allowed to inject prompts into the agent's context, run shell commands, install Python dependencies, and symlink files into the user's home directory. Audit accordingly. The bar is "would I install this on my own machine."

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: geno-tools
-site_description: Meta-CLI for installing and managing AI coding agent skillsets
+site_description: Agent-agnostic meta package manager for AI coding agents
 site_url: https://42euge.github.io/geno-tools
 repo_url: https://github.com/42euge/geno-tools
 repo_name: 42euge/geno-tools


### PR DESCRIPTION
## Summary

- Add **VISION.md** — defines the core loop (discover → absorb → evaluate → govern → evolve), maps each phase to its implementation, and articulates why it matters
- Add **TENETS.md** — seven numbered architectural principles (agent-agnostic, skill-system absorption, auditing as infrastructure, lifecycle-driven, local-first/zero telemetry, isolated by default, exact removal)
- Update **GENO.md** to reference both files via `@./VISION.md` and `@./TENETS.md` so agents load the vision alongside operational instructions
- Align **README.md**, **docs-home.md**, **architecture/index.md**, **ecosystem.md**, **onboarding/audit.md**, and **mkdocs.yml** to use the new vocabulary consistently

No code changes. All operational content (skills tables, install flows, audit checklist, conventions) is preserved.

## Test plan

- [ ] `mkdocs build` succeeds (no new warnings beyond pre-existing ones)
- [ ] VISION.md and TENETS.md are self-contained and readable standalone
- [ ] GENO.md reads coherently top-to-bottom: vision ref → tenets ref → skills → structure → subcommands → conventions
- [ ] Docs site hero, feature cards, architecture page, and ecosystem diagram reflect the lifecycle framing