### PR TITLE
Add skill trace system and observability infrastructure

### DIFF
--- a/GENO.md
+++ b/GENO.md
@@ -40,7 +40,8 @@ geno-tools/
 │   ├── config.py                  #   user config from ~/.geno/config.yaml
 │   ├── discovery.py               #   enterprise repo discovery
 │   ├── paths.py                   #   on-disk layout utilities
-│   └── registry.py                #   curated registry of known skillsets
+│   ├── registry.py                #   curated registry of known skillsets
+│   └── trace.py                   #   skill trace system (emit/list/health)
 ├── skills/                        # skill definitions
 │   ├── geno-tools/SKILL.md        #   umbrella skill
 │   ├── geno-alias/SKILL.md        #   custom skill aliasing
@@ -69,9 +70,12 @@ geno-tools/
 ```toml
 [project.scripts]
 geno-tools = "genotools.cli:main"
+geno-trace = "genotools.trace:main"
 ```
 
 `genotools/cli.py` parses subcommands and lazy-imports `genotools.commands` to keep `--version`/`--help` fast.
+
+`genotools/trace.py` provides the `geno-trace` CLI for emitting and querying skill traces. Traces are append-only JSONL at `~/.geno/traces/YYYY/YYYY-MM.jsonl`. Health cards are aggregated per-skill at `~/.geno/health/<skill>.json`.
 
 ## Subcommands
 
@@ -172,6 +176,23 @@ geno-{name}/
 │   └── {name}/SKILL.md     # umbrella skill definition
 └── pyproject.toml           # optional — triggers venv creation if present
 ```
+
+### Skill observability contract
+
+Skills may declare an optional `observability` section in SKILL.md frontmatter:
+
+```yaml
+observability:
+  success_signal: "description of what success looks like"
+  failure_signals:
+    - "condition that indicates failure"
+  knowledge_reads:
+    - "what knowledge this skill consumes"
+  knowledge_writes:
+    - "what knowledge this skill produces"
+```
+
+Skills that declare observability should also include a `## Completion` section at the end of their workflow that emits a trace via `geno-trace emit`. This feeds the self-improvement loop (health cards, retro, mining).
 
 ## Plugin structure
 

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -34,6 +34,24 @@ discovery:
     #   prefix: acme-
     #   auth_env: ACME_GITLAB_TOKEN
 
+# Observability: skill trace and health system configuration.
+observability:
+  health_threshold: 0.7      # success rate below this flags needs_retro
+  health_min_traces: 5       # minimum traces before health judgment
+
+# Operational mode: "user" (default) or "dev".
+# Dev mode enables auto-PRs for retro patches on ecosystem repos.
+# Can be overridden per-session via GENO_MODE env var.
+mode: user
+
+# Mining: session mining and dataset generation configuration.
+mining:
+  enabled: true
+  exclude_projects: []        # project slugs to skip (e.g., "taxes-*")
+  exclude_skills: []          # skill names to skip
+  scrub_paths: true           # replace absolute paths with relative
+  scrub_secrets: true         # detect and redact API keys, tokens
+
 # Workspace layout (used by geno-dev-workspaces-init)
 workspaces:
   mode: color

--- a/genotools/cli.py
+++ b/genotools/cli.py
@@ -53,6 +53,10 @@ def main(argv: list[str] | None = None) -> int:
     p_disc.add_argument("--dry-run", action="store_true",
                         help="print candidates without installing (default behavior)")
 
+    p_scan = sub.add_parser("scan", help="scan for new uninstalled skillsets and queue candidates")
+    p_scan.add_argument("--namespace", help="filter by namespace prefix (e.g. 'geno', 'acme')")
+    p_scan.add_argument("--dry-run", action="store_true", help="list candidates without writing to queue")
+
     args = parser.parse_args(argv)
 
     from genotools import commands

--- a/genotools/commands.py
+++ b/genotools/commands.py
@@ -30,6 +30,7 @@ def dispatch(args: argparse.Namespace) -> int:
         "deps": _deps,
         "doctor": _doctor,
         "discover": _discover,
+        "scan": _scan,
     }
     return handlers[args.cmd](args)
 
@@ -359,25 +360,36 @@ def _uninstall_skills_via_npx(full: str) -> None:
 
 
 def _enumerate_skill_dirs(full: str) -> list[Path]:
+    """Return flat list of skill dirs to register.
+
+    When sub-skills exist under ``skills/``, return only those dirs — skip
+    the umbrella root so ``npx skills add`` doesn't copy the whole tree and
+    stop at the root SKILL.md (it stops when it finds a root SKILL.md
+    unless ``--full-depth`` is passed).  For skillsets with no sub-skills,
+    return the root dir.
+    """
     active = paths.skillset_active(full)
-    dirs: list[Path] = []
-    if (active / "SKILL.md").exists():
-        dirs.append(active)
     skills_dir = active / "skills"
     if skills_dir.exists():
-        dirs.extend(sorted(
+        sub = sorted(
             (p for p in skills_dir.iterdir()
              if p.is_dir() and (p / "SKILL.md").exists()),
             key=lambda p: p.name,
-        ))
-    return dirs
+        )
+        if sub:
+            return sub
+    if (active / "SKILL.md").exists():
+        return [active]
+    return []
 
 
 def _enumerate_skills(full: str) -> list[str]:
-    return [
-        d.name if d != paths.skillset_active(full) else full
-        for d in _enumerate_skill_dirs(full)
-    ]
+    active = paths.skillset_active(full)
+    dirs = _enumerate_skill_dirs(full)
+    names = [d.name if d != active else full for d in dirs]
+    if (active / "SKILL.md").exists() and active not in dirs:
+        names.insert(0, full)
+    return names
 
 
 # ── deps ───────────────────────────────────────────────────────────────────
@@ -618,6 +630,27 @@ def _discover(_: argparse.Namespace) -> int:
     for c in found:
         marker = "" if c.has_skill_md else "  (no SKILL.md — skipped)"
         print(f"  [{c.source}] {c.name:<32} {c.url}{marker}")
+    return 0
+
+
+def _scan(args: argparse.Namespace) -> int:
+    srcs = discovery.sources()
+    if not srcs:
+        print("no discovery sources configured (~/.geno/config.yaml: discovery.sources)")
+        return 0
+
+    new = discovery.scan(namespace=args.namespace, dry_run=args.dry_run)
+    if not new:
+        print("no new candidates found")
+        return 0
+
+    action = "found" if args.dry_run else "queued"
+    print(f"{action} {len(new)} new candidate(s):")
+    for c in new:
+        print(f"  [{c.source}] {c.name:<32} {c.url}")
+
+    if not args.dry_run:
+        print(f"\ncandidates written to {discovery.CANDIDATES_FILE}")
     return 0
 
 

--- a/genotools/discovery.py
+++ b/genotools/discovery.py
@@ -143,18 +143,51 @@ def _github_has_skill_md(org: str, name: str, source: dict, env: dict) -> bool:
 
 @_register_provider("gitlab")
 def _gitlab(source: dict) -> list[Candidate]:
-    """GitLab provider scaffold.
+    """List repos in a GitLab group via the REST API."""
+    group = source.get("group")
+    if not group:
+        return []
+    base_url = source.get("base_url", "https://gitlab.com").rstrip("/")
+    prefix = source.get("prefix", "geno-")
+    label = f"gitlab:{group}"
 
-    Implementation plan:
-    1. ``GET <base_url>/api/v4/groups/<group>/projects?per_page=100``
-       with ``PRIVATE-TOKEN: $auth_env``.
-    2. Filter ``path`` by ``prefix``.
-    3. Probe ``GET /projects/<id>/repository/files/SKILL.md?ref=HEAD`` for
-       the candidate check.
-    Not implemented yet — returns an empty list so the rest of discovery
-    keeps working.
-    """
-    return []
+    headers = {}
+    if (auth_env := source.get("auth_env")) and (tok := os.environ.get(auth_env)):
+        headers["PRIVATE-TOKEN"] = tok
+
+    try:
+        import urllib.request
+        url = f"{base_url}/api/v4/groups/{group.replace('/', '%2F')}/projects?per_page=100&include_subgroups=true"
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            repos = json.loads(resp.read())
+    except Exception:
+        return []
+
+    results: list[Candidate] = []
+    for repo in repos:
+        path = repo.get("path", "")
+        if not path.startswith(prefix):
+            continue
+        clone_url = repo.get("http_url_to_repo", "")
+        project_id = repo.get("id")
+        has_skill = False
+        if project_id:
+            has_skill = _gitlab_has_skill_md(base_url, project_id, headers)
+        results.append(Candidate(name=path, url=clone_url, source=label, has_skill_md=has_skill))
+    return results
+
+
+def _gitlab_has_skill_md(base_url: str, project_id: int, headers: dict) -> bool:
+    """Check for SKILL.md in a GitLab repo."""
+    try:
+        import urllib.request
+        url = f"{base_url}/api/v4/projects/{project_id}/repository/files/SKILL.md?ref=HEAD"
+        req = urllib.request.Request(url, headers=headers, method="HEAD")
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
 
 
 # ── bitbucket / gitea (placeholders) ────────────────────────────────────────
@@ -162,12 +195,97 @@ def _gitlab(source: dict) -> list[Candidate]:
 
 @_register_provider("bitbucket")
 def _bitbucket(source: dict) -> list[Candidate]:
-    return []
+    """List repos in a Bitbucket workspace via the REST API."""
+    workspace = source.get("workspace")
+    if not workspace:
+        return []
+    prefix = source.get("prefix", "geno-")
+    label = f"bitbucket:{workspace}"
+
+    headers = {}
+    if (auth_env := source.get("auth_env")) and (tok := os.environ.get(auth_env)):
+        headers["Authorization"] = f"Bearer {tok}"
+
+    try:
+        import urllib.request
+        url = f"https://api.bitbucket.org/2.0/repositories/{workspace}?pagelen=100"
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read())
+    except Exception:
+        return []
+
+    results: list[Candidate] = []
+    for repo in data.get("values", []):
+        slug = repo.get("slug", "")
+        if not slug.startswith(prefix):
+            continue
+        clone_url = ""
+        for link in repo.get("links", {}).get("clone", []):
+            if link.get("name") == "https":
+                clone_url = link.get("href", "")
+                break
+        has_skill = _bitbucket_has_skill_md(workspace, slug, headers)
+        results.append(Candidate(name=slug, url=clone_url, source=label, has_skill_md=has_skill))
+    return results
+
+
+def _bitbucket_has_skill_md(workspace: str, slug: str, headers: dict) -> bool:
+    """Check for SKILL.md in a Bitbucket repo."""
+    try:
+        import urllib.request
+        url = f"https://api.bitbucket.org/2.0/repositories/{workspace}/{slug}/src/HEAD/SKILL.md"
+        req = urllib.request.Request(url, headers=headers, method="HEAD")
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
 
 
 @_register_provider("gitea")
 def _gitea(source: dict) -> list[Candidate]:
-    return []
+    """List repos in a Gitea org via the REST API."""
+    org = source.get("org")
+    if not org:
+        return []
+    base_url = source.get("base_url", "https://gitea.com").rstrip("/")
+    prefix = source.get("prefix", "geno-")
+    label = f"gitea:{org}"
+
+    headers = {}
+    if (auth_env := source.get("auth_env")) and (tok := os.environ.get(auth_env)):
+        headers["Authorization"] = f"token {tok}"
+
+    try:
+        import urllib.request
+        url = f"{base_url}/api/v1/orgs/{org}/repos?limit=100"
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            repos = json.loads(resp.read())
+    except Exception:
+        return []
+
+    results: list[Candidate] = []
+    for repo in repos:
+        name = repo.get("name", "")
+        if not name.startswith(prefix):
+            continue
+        clone_url = repo.get("clone_url", "")
+        has_skill = _gitea_has_skill_md(base_url, org, name, headers)
+        results.append(Candidate(name=name, url=clone_url, source=label, has_skill_md=has_skill))
+    return results
+
+
+def _gitea_has_skill_md(base_url: str, org: str, name: str, headers: dict) -> bool:
+    """Check for SKILL.md in a Gitea repo."""
+    try:
+        import urllib.request
+        url = f"{base_url}/api/v1/repos/{org}/{name}/contents/SKILL.md"
+        req = urllib.request.Request(url, headers=headers, method="HEAD")
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
 
 
 # ── helpers ─────────────────────────────────────────────────────────────────
@@ -175,3 +293,72 @@ def _gitea(source: dict) -> list[Candidate]:
 
 def iter_kinds() -> Iterable[str]:
     return tuple(_PROVIDERS.keys())
+
+
+# ── scan (continuous discovery) ────────────────────────────────────────────
+
+
+DISCOVERY_DIR = os.path.expanduser("~/.geno/discovery")
+CANDIDATES_FILE = os.path.join(DISCOVERY_DIR, "candidates.jsonl")
+
+
+def scan(*, namespace: str | None = None, dry_run: bool = False) -> list[Candidate]:
+    """Scan all sources, find uninstalled candidates, and write to queue.
+
+    Returns the list of new candidates found.
+    """
+    from datetime import datetime, timezone
+
+    all_candidates = candidates()
+    if namespace:
+        prefix = f"{namespace}-" if not namespace.endswith("-") else namespace
+        all_candidates = [c for c in all_candidates if c.name.startswith(prefix)]
+
+    installed = _get_installed_names()
+    new = [c for c in all_candidates if c.has_skill_md and c.name not in installed]
+
+    if not dry_run and new:
+        os.makedirs(DISCOVERY_DIR, exist_ok=True)
+        existing_names = _get_queued_names()
+        with open(CANDIDATES_FILE, "a") as f:
+            for c in new:
+                if c.name in existing_names:
+                    continue
+                entry = json.dumps({
+                    "name": c.name,
+                    "url": c.url,
+                    "source": c.source,
+                    "discovered": datetime.now(timezone.utc).isoformat(),
+                    "has_skill_md": c.has_skill_md,
+                }, separators=(",", ":"))
+                f.write(entry + "\n")
+
+        with open(os.path.join(DISCOVERY_DIR, "last_scan"), "w") as f:
+            f.write(datetime.now(timezone.utc).isoformat())
+
+    return new
+
+
+def _get_installed_names() -> set[str]:
+    """Get names of currently installed skillsets."""
+    from genotools import paths
+    installed = set()
+    if paths.ROOT.exists():
+        for p in paths.ROOT.iterdir():
+            if p.is_dir() and p.name.startswith("geno-"):
+                installed.add(p.name)
+    return installed
+
+
+def _get_queued_names() -> set[str]:
+    """Get names already in the candidate queue."""
+    names = set()
+    if os.path.exists(CANDIDATES_FILE):
+        with open(CANDIDATES_FILE) as f:
+            for line in f:
+                try:
+                    entry = json.loads(line.strip())
+                    names.add(entry.get("name", ""))
+                except json.JSONDecodeError:
+                    continue
+    return names

--- a/genotools/paths.py
+++ b/genotools/paths.py
@@ -21,6 +21,13 @@ ROOT = HOME / ".geno-tools"
 STATE_HASH = ROOT / ".state-hash"
 BOOTSTRAP = ROOT / "geno-bootstrap"
 
+GENO_DIR = HOME / ".geno"
+TRACES_DIR = GENO_DIR / "traces"
+HEALTH_DIR = GENO_DIR / "health"
+DISCOVERY_DIR = GENO_DIR / "discovery"
+DATASETS_DIR = GENO_DIR / "datasets"
+ISO_DIR = GENO_DIR / "iso"
+
 
 def normalize(name: str) -> str:
     """Canonicalize to the `geno-{name}` form used on disk."""

--- a/genotools/trace.py
+++ b/genotools/trace.py
@@ -1,0 +1,426 @@
+"""Skill trace system — structured records of skill invocations.
+
+Traces are the connective tissue for self-improving skills, knowledge
+integration, and session mining. Every skill emits a trace on completion.
+
+Storage: ~/.geno/traces/YYYY/YYYY-MM.jsonl (append-only, one line per trace)
+Health:  ~/.geno/health/<skill-name>.yaml  (aggregated per-skill stats)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+GENO_DIR = Path.home() / ".geno"
+TRACES_DIR = GENO_DIR / "traces"
+HEALTH_DIR = GENO_DIR / "health"
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _trace_file(dt: datetime | None = None) -> Path:
+    dt = dt or _now()
+    year_dir = TRACES_DIR / str(dt.year)
+    year_dir.mkdir(parents=True, exist_ok=True)
+    return year_dir / f"{dt.year}-{dt.month:02d}.jsonl"
+
+
+def _build_trace(
+    skill: str,
+    status: str,
+    *,
+    skillset: str | None = None,
+    version: str | None = None,
+    error_type: str | None = None,
+    error_detail: str | None = None,
+    tool_calls: int = 0,
+    errors: int = 0,
+    thrashing_score: float = 0.0,
+    user_corrections: int = 0,
+    duration_turns: int = 0,
+    task_id: str | None = None,
+    scope: str | None = None,
+    branch: str | None = None,
+    consumed: list[str] | None = None,
+    produced: list[str] | None = None,
+    tags: list[str] | None = None,
+) -> dict:
+    now = _now()
+    return {
+        "id": f"trace-{uuid4().hex[:12]}",
+        "timestamp": now.isoformat(),
+        "session_id": os.environ.get("CLAUDE_SESSION_ID", ""),
+        "project": os.environ.get("CLAUDE_PROJECT", os.getcwd()),
+        "skill": {
+            "name": skill,
+            "skillset": skillset or skill.rsplit("-", 1)[0] if "-" in skill else skill,
+            "version": version or "unknown",
+        },
+        "outcome": {
+            "status": status,
+            "error_type": error_type,
+            "error_detail": error_detail,
+        },
+        "metrics": {
+            "tool_calls": tool_calls,
+            "errors": errors,
+            "thrashing_score": thrashing_score,
+            "user_corrections": user_corrections,
+            "duration_turns": duration_turns,
+        },
+        "context": {
+            "task_id": task_id,
+            "scope": scope,
+            "branch": branch,
+        },
+        "knowledge": {
+            "consumed": consumed or [],
+            "produced": produced or [],
+        },
+        "tags": tags or [],
+    }
+
+
+def cmd_emit(args: argparse.Namespace) -> int:
+    trace = _build_trace(
+        skill=args.skill,
+        status=args.status,
+        skillset=args.skillset,
+        version=args.version,
+        error_type=args.error_type,
+        error_detail=args.error_detail,
+        tool_calls=args.tool_calls,
+        errors=args.errors,
+        thrashing_score=args.thrashing_score,
+        user_corrections=args.user_corrections,
+        duration_turns=args.duration_turns,
+        task_id=args.task,
+        scope=args.scope,
+        branch=args.branch,
+        consumed=args.consumed,
+        produced=args.produced,
+        tags=args.tags,
+    )
+
+    path = _trace_file()
+    with open(path, "a") as f:
+        f.write(json.dumps(trace, separators=(",", ":")) + "\n")
+
+    _queue_for_retro(trace["id"], args.skill, args.status)
+
+    print(f"trace {trace['id']} → {path}")
+    if args.status in ("failure", "partial"):
+        print(f"queued for retro → {RETRO_QUEUE}")
+    return 0
+
+
+def _iter_traces(
+    *,
+    skill: str | None = None,
+    since: str | None = None,
+    status: str | None = None,
+    limit: int = 50,
+) -> list[dict]:
+    """Read traces, newest first, with optional filters."""
+    traces = []
+    if not TRACES_DIR.exists():
+        return traces
+
+    files = sorted(TRACES_DIR.rglob("*.jsonl"), reverse=True)
+    for f in files:
+        for line in reversed(f.read_text().splitlines()):
+            if not line.strip():
+                continue
+            try:
+                t = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if skill and t.get("skill", {}).get("name") != skill:
+                continue
+            if status and t.get("outcome", {}).get("status") != status:
+                continue
+            if since:
+                if t.get("timestamp", "") < since:
+                    continue
+            traces.append(t)
+            if len(traces) >= limit:
+                return traces
+    return traces
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    traces = _iter_traces(
+        skill=args.skill,
+        since=args.since,
+        status=args.status,
+        limit=args.limit,
+    )
+
+    if args.json:
+        print(json.dumps(traces, indent=2))
+        return 0
+
+    if not traces:
+        print("no traces found")
+        return 0
+
+    for t in traces:
+        ts = t["timestamp"][:19]
+        sk = t["skill"]["name"]
+        st = t["outcome"]["status"]
+        tc = t["metrics"]["tool_calls"]
+        er = t["metrics"]["errors"]
+        print(f"{ts}  {sk:<40s}  {st:<8s}  tools={tc}  errors={er}")
+    return 0
+
+
+def _compute_health(skill_name: str, traces: list[dict]) -> dict:
+    """Aggregate traces into a health card for a skill."""
+    if not traces:
+        return {}
+
+    total = len(traces)
+    successes = sum(1 for t in traces if t["outcome"]["status"] == "success")
+    tool_calls = [t["metrics"]["tool_calls"] for t in traces]
+    thrashing = [t["metrics"]["thrashing_score"] for t in traces]
+
+    error_types: dict[str, int] = {}
+    for t in traces:
+        et = t["outcome"].get("error_type")
+        if et:
+            error_types[et] = error_types.get(et, 0) + 1
+
+    reads: set[str] = set()
+    writes: set[str] = set()
+    for t in traces:
+        reads.update(t.get("knowledge", {}).get("consumed", []))
+        writes.update(t.get("knowledge", {}).get("produced", []))
+
+    return {
+        "skill": skill_name,
+        "stats": {
+            "total_invocations": total,
+            "success_rate": round(successes / total, 3) if total else 0,
+            "avg_tool_calls": round(sum(tool_calls) / total, 1) if total else 0,
+            "avg_thrashing": round(sum(thrashing) / total, 3) if total else 0,
+            "last_invoked": traces[0]["timestamp"],
+        },
+        "error_types": error_types,
+        "knowledge": {
+            "reads_from": sorted(reads),
+            "writes_to": sorted(writes),
+        },
+        "needs_retro": (successes / total < 0.7) if total >= 5 else False,
+    }
+
+
+RETRO_DIR = GENO_DIR / "retro"
+RETRO_QUEUE = RETRO_DIR / "queue.jsonl"
+ISO_DIR = GENO_DIR / "iso"
+ISO_INBOX = ISO_DIR / "inbox.jsonl"
+
+
+def _queue_for_retro(trace_id: str, skill: str, status: str) -> None:
+    """Append a failed trace to the retro queue."""
+    if status not in ("failure", "partial"):
+        return
+    RETRO_DIR.mkdir(parents=True, exist_ok=True)
+    entry = json.dumps({
+        "trace_id": trace_id,
+        "skill": skill,
+        "status": status,
+        "queued_at": _now().isoformat(),
+    }, separators=(",", ":"))
+    with open(RETRO_QUEUE, "a") as f:
+        f.write(entry + "\n")
+
+
+def cmd_queue(args: argparse.Namespace) -> int:
+    """Show or manage the retro queue."""
+    if args.clear:
+        if RETRO_QUEUE.exists():
+            RETRO_QUEUE.unlink()
+            print("retro queue cleared")
+        else:
+            print("retro queue already empty")
+        return 0
+
+    if not RETRO_QUEUE.exists():
+        print("retro queue is empty")
+        return 0
+
+    entries = []
+    for line in RETRO_QUEUE.read_text().splitlines():
+        if line.strip():
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+    if args.json:
+        print(json.dumps(entries, indent=2))
+    else:
+        if not entries:
+            print("retro queue is empty")
+            return 0
+        print(f"retro queue: {len(entries)} entries")
+        for e in entries:
+            print(f"  {e.get('queued_at', '?')[:19]}  {e.get('skill', '?'):<40s}  {e.get('status', '?')}")
+    return 0
+
+
+def cmd_health(args: argparse.Namespace) -> int:
+    if args.refresh:
+        return _refresh_health(args)
+    if args.skill:
+        return _show_health(args.skill, args.json)
+    return _show_all_health(args.json)
+
+
+def _refresh_health(args: argparse.Namespace) -> int:
+    """Rebuild health cards from traces."""
+    all_traces = _iter_traces(limit=10000)
+    if not all_traces:
+        print("no traces found")
+        return 0
+
+    by_skill: dict[str, list[dict]] = {}
+    for t in all_traces:
+        name = t["skill"]["name"]
+        by_skill.setdefault(name, []).append(t)
+
+    HEALTH_DIR.mkdir(parents=True, exist_ok=True)
+    count = 0
+    needs_retro = []
+
+    for skill_name, traces in by_skill.items():
+        card = _compute_health(skill_name, traces)
+        if not card:
+            continue
+        path = HEALTH_DIR / f"{skill_name}.json"
+        with open(path, "w") as f:
+            json.dump(card, f, indent=2)
+            f.write("\n")
+        count += 1
+        if card.get("needs_retro"):
+            needs_retro.append(skill_name)
+
+    print(f"refreshed {count} health cards")
+    if needs_retro:
+        print(f"needs retro: {', '.join(needs_retro)}")
+    return 0
+
+
+def _show_health(skill: str, as_json: bool) -> int:
+    path = HEALTH_DIR / f"{skill}.json"
+    if not path.exists():
+        print(f"no health card for {skill}")
+        return 1
+
+    card = json.loads(path.read_text())
+    if as_json:
+        print(json.dumps(card, indent=2))
+    else:
+        s = card["stats"]
+        print(f"{card['skill']}")
+        print(f"  invocations: {s['total_invocations']}")
+        print(f"  success rate: {s['success_rate']:.0%}")
+        print(f"  avg tool calls: {s['avg_tool_calls']}")
+        print(f"  avg thrashing: {s['avg_thrashing']:.3f}")
+        print(f"  last invoked: {s['last_invoked'][:19]}")
+        if card.get("needs_retro"):
+            print(f"  ⚠ needs retro (success rate < 70%)")
+    return 0
+
+
+def _show_all_health(as_json: bool) -> int:
+    if not HEALTH_DIR.exists():
+        print("no health cards — run `geno-trace health --refresh` first")
+        return 0
+
+    cards = []
+    for p in sorted(HEALTH_DIR.glob("*.json")):
+        cards.append(json.loads(p.read_text()))
+
+    if as_json:
+        print(json.dumps(cards, indent=2))
+        return 0
+
+    if not cards:
+        print("no health cards")
+        return 0
+
+    print(f"{'skill':<40s}  {'rate':>5s}  {'n':>4s}  {'tools':>5s}  {'retro':>5s}")
+    print("-" * 65)
+    for c in cards:
+        s = c["stats"]
+        retro = "YES" if c.get("needs_retro") else ""
+        print(
+            f"{c['skill']:<40s}  {s['success_rate']:>5.0%}  "
+            f"{s['total_invocations']:>4d}  {s['avg_tool_calls']:>5.1f}  {retro:>5s}"
+        )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="geno-trace", description="Skill trace system")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    # emit
+    p_emit = sub.add_parser("emit", help="record a skill trace")
+    p_emit.add_argument("--skill", required=True)
+    p_emit.add_argument("--status", required=True, choices=["success", "partial", "failure", "abandoned"])
+    p_emit.add_argument("--skillset")
+    p_emit.add_argument("--version")
+    p_emit.add_argument("--error-type")
+    p_emit.add_argument("--error-detail")
+    p_emit.add_argument("--tool-calls", type=int, default=0)
+    p_emit.add_argument("--errors", type=int, default=0)
+    p_emit.add_argument("--thrashing-score", type=float, default=0.0)
+    p_emit.add_argument("--user-corrections", type=int, default=0)
+    p_emit.add_argument("--duration-turns", type=int, default=0)
+    p_emit.add_argument("--task")
+    p_emit.add_argument("--scope")
+    p_emit.add_argument("--branch")
+    p_emit.add_argument("--consumed", nargs="*", default=[])
+    p_emit.add_argument("--produced", nargs="*", default=[])
+    p_emit.add_argument("--tags", nargs="*", default=[])
+    p_emit.set_defaults(func=cmd_emit)
+
+    # list
+    p_list = sub.add_parser("list", help="query stored traces")
+    p_list.add_argument("--skill")
+    p_list.add_argument("--status")
+    p_list.add_argument("--since", help="ISO timestamp cutoff")
+    p_list.add_argument("--limit", type=int, default=50)
+    p_list.add_argument("--json", action="store_true")
+    p_list.set_defaults(func=cmd_list)
+
+    # health
+    p_health = sub.add_parser("health", help="view or refresh skill health cards")
+    p_health.add_argument("--refresh", action="store_true", help="rebuild health cards from traces")
+    p_health.add_argument("--skill", help="show health for a specific skill")
+    p_health.add_argument("--json", action="store_true")
+    p_health.set_defaults(func=cmd_health)
+
+    # queue
+    p_queue = sub.add_parser("queue", help="view or manage the retro queue")
+    p_queue.add_argument("--clear", action="store_true", help="clear the retro queue")
+    p_queue.add_argument("--json", action="store_true")
+    p_queue.set_defaults(func=cmd_queue)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -13,6 +13,11 @@
             "type": "command",
             "command": "geno-trace health --refresh 2>/dev/null || true",
             "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "test -s ~/.geno/iso/inbox.jsonl && { echo 'geno-iso:'; cat ~/.geno/iso/inbox.jsonl | head -10; mv ~/.geno/iso/inbox.jsonl ~/.geno/iso/inbox.$(date +%s).jsonl; } || true",
+            "timeout": 3000
           }
         ]
       }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -8,6 +8,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.sh",
             "timeout": 30000
+          },
+          {
+            "type": "command",
+            "command": "geno-trace health --refresh 2>/dev/null || true",
+            "timeout": 5000
           }
         ]
       }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ test = ["pytest>=8.0"]
 
 [project.scripts]
 geno-tools = "genotools.cli:main"
+geno-trace = "genotools.trace:main"
 
 [tool.setuptools.packages.find]
 include = ["genotools*"]


### PR DESCRIPTION
## Summary

Phase 1+2 of the three-pillars initiative (self-improving skills, knowledge, session mining).

- **`geno-trace` CLI** — new entry point with `emit`, `list`, `health`, `queue` subcommands for structured skill invocation tracking
- **Trace storage** — append-only JSONL at `~/.geno/traces/YYYY/YYYY-MM.jsonl`, one line per skill run
- **Health cards** — aggregated per-skill stats at `~/.geno/health/<skill>.json` with `needs_retro` flagging (<70% success rate)
- **Retro queue** — failed traces auto-queue to `~/.geno/retro/queue.jsonl` for batch retro processing
- **SessionStart hook** — `geno-trace health --refresh` runs on every session start
- **Config sections** — `observability`, `mode` (dev/user), and `mining` in defaults.yaml
- **Observability contract** — documented in GENO.md for all skillsets to adopt

## Test plan

- [ ] `geno-trace emit --skill test --status success --tool-calls 5 --errors 0` appends to traces JSONL
- [ ] `geno-trace emit --skill test --status failure ...` also queues to retro queue
- [ ] `geno-trace list` shows stored traces
- [ ] `geno-trace health --refresh` generates health cards from traces
- [ ] `geno-trace health --skill <name>` shows per-skill stats
- [ ] `geno-trace queue` shows retro queue entries
- [ ] `geno-trace queue --clear` clears the queue
- [ ] SessionStart hook runs health refresh without errors