### PR TITLE
chore(geno-audit): bring geno-tools into ecosystem compliance

### DIFF
--- a/GENO.md
+++ b/GENO.md
@@ -91,6 +91,9 @@ geno-trace = "genotools.trace:main"
 | `geno-tools use <name>@<variant> [--here]` | stub |
 | `geno-tools promote <name> <variant>` | stub |
 | `geno-tools doctor` | stub |
+| `geno-tools discover [--dry-run]` | implemented |
+| `geno-tools scan [--namespace] [--dry-run]` | implemented |
+| `geno-tools docs [--docs-dir] [--dry-run]` | implemented |
 
 ## Dependency management
 
@@ -153,6 +156,10 @@ aliases:
 
 The prefix is applied at install time by `geno-tools install` when materializing skills via `npx skills add`. Never hardcode an aliased prefix like `gt-` in SKILL.md descriptions, GENO.md, or any committed file. See `config/defaults.yaml` for the full schema.
 
+### Versioning
+
+The canonical version lives in `genotools.yaml` (`version` field). The same value must appear in `pyproject.toml` (`project.version`), `package.json` (`version`), and `genotools/__init__.py` (`__version__`). Bump the version whenever skills are added, removed, or behavior changes. Keep all four files in sync.
+
 ### Adding a new skill
 
 To add a new skill to this repo:
@@ -162,6 +169,7 @@ To add a new skill to this repo:
 3. Update the umbrella skill description in `skills/geno-tools/SKILL.md` to list the new skill.
 4. Add the skill to the skills table in this file (`GENO.md`).
 5. If the skill needs docs, add a page under `docs/`.
+6. Bump the version in all four files: `genotools.yaml`, `pyproject.toml`, `package.json`, `genotools/__init__.py`.
 
 ### What a skillset repo needs to provide
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ gemini extensions install https://github.com/42euge/geno-tools
 bash ~/.gemini/extensions/geno-tools/scripts/bootstrap.sh
 ```
 
-Gemini clones the repo into `~/.gemini/extensions/geno-tools/`, reads `gemini-extension.json`, and registers the bundled `skills/`, `commands/`, and `hooks/hooks.json`. Restart the CLI to pick it up. Update later with `gemini extensions update geno-tools`. Gemini extensions don't run arbitrary startup commands, so the one-time `bootstrap.sh` invocation is what puts `geno-tools` on PATH.
+Gemini clones the repo into `~/.gemini/extensions/geno-tools/`, reads `gemini-extension.json`, and registers the bundled `skills/` and `hooks/hooks.json`. Restart the CLI to pick it up. Update later with `gemini extensions update geno-tools`. Gemini extensions don't run arbitrary startup commands, so the one-time `bootstrap.sh` invocation is what puts `geno-tools` on PATH.
 
 ### Cursor
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ Inside each skillset:
 
 - `SKILL.md` at the root — the umbrella manifest the agent loads first
 - `skills/<subskill>/SKILL.md` — **subskillsets**, each scoped to one focused capability (a single skillset typically ships several). geno-tools registers all of them in one shot via `npx skills add --skill '*'`.
-- `commands/*.md` — slash commands surfaced as `/{configured-prefix}-*` in the agent
 - Optional `pyproject.toml`, runtime scripts, and copy-once configs
 
 Subskillsets keep individual SKILL.md files small and tightly scoped, while the umbrella SKILL.md gives the agent enough context to discover them.
@@ -135,7 +134,7 @@ There are three ways to make a skillset installable through `geno-tools install`
 2. **Direct git URL** — anyone can install any compliant repo without a registry entry: `geno-tools install https://github.com/you/your-skillset.git`. This is the recommended path for private, internal, or experimental skillsets.
 3. **Local dev link** — `geno-tools dev <repo-name> ~/src/<repo-name>` to iterate on a checkout without committing.
 
-A minimum viable skillset only needs a root `SKILL.md` and a `commands/` directory; everything else (venv, runtime symlinks, configs, subskillsets) is opt-in.
+A minimum viable skillset only needs a root `SKILL.md`, a `genotools.yaml`, and a `GENO.md`; everything else (venv, runtime symlinks, configs, subskillsets) is opt-in.
 
 ## Existing geno-* repos
 
@@ -185,7 +184,7 @@ Lower-level building blocks that power skillsets and the agent itself:
 
 geno-tools is built so an organization can run the same agentic stack as the open-source community without leaking proprietary prompts, code, or data.
 
-The pattern is to mirror the `geno-*` convention under your own namespace: `{company-slug}-{skillset-slug}`. For example, an internal skillset for incident response at Acme would live in a repo named `acme-incident-response`, and a finance skillset would be `acme-finance`. Same layout, same `SKILL.md` + `commands/` + optional venv shape — just hosted privately.
+The pattern is to mirror the `geno-*` convention under your own namespace: `{company-slug}-{skillset-slug}`. For example, an internal skillset for incident response at Acme would live in a repo named `acme-incident-response`, and a finance skillset would be `acme-finance`. Same layout, same `SKILL.md` + `genotools.yaml` + `GENO.md` + optional venv shape — just hosted privately.
 
 How it works in practice:
 

--- a/skills/geno-tools/SKILL.md
+++ b/skills/geno-tools/SKILL.md
@@ -32,10 +32,15 @@ Install by full repo name (e.g. `geno-tools install geno-<name>`):
 | Skill | Description |
 |-------|-------------|
 | geno-alias | Create, remove, and list custom slash-command aliases |
+| geno-audit | Audit a geno-ecosystem repo for compliance with skillset conventions |
 | geno-data-workspaces-init | Create data workspaces for personal/life skills (taxes, remodel, career) |
+| geno-icons | Generate pixel-art icons for geno ecosystem repos |
+| geno-onboarding | Onboarding wizard for new geno ecosystem skillsets |
 | geno-skills-create | Scaffold a new skill in a geno ecosystem repo |
 | geno-skills-install | Install skills from a local repo checkout globally |
 | geno-skills-status | Show version, commit, and freshness of installed skillsets |
+| geno-tools-open-docs | Open the geno-tools documentation site |
+| geno-tools-update | Pull the latest version of installed skillsets and re-register with all agents |
 
 ## Commands
 

--- a/skills/geno-tools/SKILL.md
+++ b/skills/geno-tools/SKILL.md
@@ -5,6 +5,9 @@ description: >-
   Use when user asks about installing, removing, listing, or updating
   geno ecosystem skillsets.
 allowed-tools: "Bash(geno-tools *) Bash(python3 -m genotools *)"
+metadata:
+  author: 42euge
+  version: "0.1.0"
 ---
 
 # geno-tools — Skillset Manager


### PR DESCRIPTION
## Audit Report: geno-tools

Automated compliance audit via `geno-audit`.

### Summary
```
PASS: ~35   FAIL: 0 (fixed: 0)   WARN: 3 (fixed: 3)   INFO: 2
```

### Changes

**GENO.md — Subcommands table & Conventions section**
- Added missing `discover`, `scan`, and `docs` subcommands to the Subcommands table (were implemented but not listed)
- Added `### Versioning` convention subsection: identifies `genotools.yaml`, `pyproject.toml`, `package.json`, and `genotools/__init__.py` as the four canonical version files and states they must be kept in sync
- Added version-bump step (step 6) to the "Adding a new skill" checklist

**README.md — Minimum viable skillset description**
- Removed reference to legacy `commands/*.md` slash-command pattern (that directory convention is deprecated; skills live under `skills/` now)
- Updated "minimum viable skillset" description to correctly list `SKILL.md`, `genotools.yaml`, and `GENO.md` as the required files

**skills/geno-tools/SKILL.md — Umbrella skill listing**
- Added missing skills to the sub-skill table: `geno-audit`, `geno-icons`, `geno-onboarding`, `geno-tools-open-docs`, `geno-tools-update`

### Remaining items

- **INFO**: `docs/assets/icon.png` — run `/geno-icons` to generate or refresh the project icon
- **INFO**: No git tags exist on this repo — version bump tracking against tags is not applicable until the first tag is created

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8sY1znqokcjUrVuRYsnkP)_