### PR TITLE
Refactor docs and plugin wiring for Antigravity CLI

### DIFF
--- a/GENO.md
+++ b/GENO.md
@@ -1,6 +1,6 @@
 # geno-tools — Agent-Agnostic Meta Package Manager for AI Coding Agents
 
-`geno-tools` is an agent-agnostic meta package manager for AI coding agents. It discovers skills from open-source and private ecosystems, absorbs external skill systems (Vercel Labs Skills, Superpowers, Ralphy Loop plugins) into a unified framework, and manages their lifecycle across all supported agents (Claude Code, Gemini CLI, Codex, OpenCode, Cursor). A meta-harness layer evaluates and refines skill variations over time, while built-in auditing ensures capabilities evolve safely.
+`geno-tools` is an agent-agnostic meta package manager for AI coding agents. It discovers skills from open-source and private ecosystems, absorbs external skill systems (Vercel Labs Skills, Superpowers, Ralphy Loop plugins) into a unified framework, and manages their lifecycle across all supported agents (Claude Code, Antigravity CLI, Codex, OpenCode, Cursor). A meta-harness layer evaluates and refines skill variations over time, while built-in auditing ensures capabilities evolve safely.
 
 @./VISION.md
 @./TENETS.md
@@ -32,9 +32,9 @@ geno-tools/
 ├── SKILL.md -> skills/geno-tools/SKILL.md  # umbrella skill manifest
 ├── genotools.yaml                 # geno-tools manifest
 ├── CLAUDE.md                      # Claude Code pointer -> GENO.md
-├── GEMINI.md                      # Gemini CLI pointer -> GENO.md
+├── GEMINI.md                      # legacy pointer -> GENO.md
 ├── AGENTS.md                      # Codex pointer -> GENO.md
-├── gemini-extension.json          # Gemini CLI extension descriptor
+├── gemini-extension.json          # legacy extension descriptor
 ├── package.json                   # npm metadata (OpenCode plugin entry)
 ├── pyproject.toml                 # Python package metadata
 ├── genotools/                     # Python CLI package
@@ -65,6 +65,7 @@ geno-tools/
 ├── .claude-plugin/plugin.json     # Claude Code plugin manifest
 ├── .codex-plugin/plugin.json      # Codex CLI plugin manifest
 ├── .cursor-plugin/plugin.json     # Cursor plugin manifest
+├── plugin.json                    # Antigravity CLI plugin manifest
 ├── .opencode/                     # OpenCode plugin
 └── tests/                         # pytest suite
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://42euge.github.io/geno-tools/)
 
-Agent-agnostic meta package manager for AI coding agents. Discovers, absorbs, evaluates, and governs skills across Claude Code, Codex, Gemini CLI, Cursor, and OpenCode.
+Agent-agnostic meta package manager for AI coding agents. Discovers, absorbs, evaluates, and governs skills across Claude Code, Codex, Antigravity CLI, Cursor, and OpenCode.
 
 **Website:** <https://42euge.github.io/geno-tools>
 
@@ -21,7 +21,7 @@ Agent-agnostic meta package manager for AI coding agents. Discovers, absorbs, ev
 
 geno-tools ships as a native plugin/extension on each supported coding CLI. Pick the snippet for the CLI you use — every path bootstraps `~/.geno/` from `config/defaults.yaml` and self-installs the `geno-tools` shell command onto PATH (via `pipx`, falling back to `pip install --user`) the first time the agent loads the plugin.
 
-The bootstrap lives at `scripts/bootstrap.sh`. CLIs that expose a startup hook for arbitrary commands (Claude Code, OpenCode) run it automatically. The others (Gemini CLI, Codex, Cursor) need a one-time `bash <plugin-root>/scripts/bootstrap.sh` invocation, shown inline below.
+The bootstrap lives at `scripts/bootstrap.sh`. CLIs that expose a startup hook for arbitrary commands (Claude Code, OpenCode) run it automatically. The others (Antigravity CLI, Codex, Cursor) need a one-time `bash <plugin-root>/scripts/bootstrap.sh` invocation, shown inline below.
 
 ### Claude Code
 
@@ -45,14 +45,14 @@ bash ~/.codex/plugins/cache/geno-tools/geno-tools/*/scripts/bootstrap.sh
 
 The marketplace catalog at `.agents/plugins/marketplace.json` exposes the plugin; pick `geno-tools` from the `/plugins` browser and toggle it on. (Plugins are cached at `~/.codex/plugins/cache/geno-tools/geno-tools/<version>/`.) Codex doesn't expose a portable startup hook for arbitrary commands, so run `bootstrap.sh` once — it's idempotent on later invocations.
 
-### Gemini CLI
+### Antigravity CLI
 
 ```bash
-gemini extensions install https://github.com/42euge/geno-tools
-bash ~/.gemini/extensions/geno-tools/scripts/bootstrap.sh
+agy plugin install https://github.com/42euge/geno-tools
+bash ~/.gemini/antigravity-cli/plugins/geno-tools/scripts/bootstrap.sh
 ```
 
-Gemini clones the repo into `~/.gemini/extensions/geno-tools/`, reads `gemini-extension.json`, and registers the bundled `skills/` and `hooks/hooks.json`. Restart the CLI to pick it up. Update later with `gemini extensions update geno-tools`. Gemini extensions don't run arbitrary startup commands, so the one-time `bootstrap.sh` invocation is what puts `geno-tools` on PATH.
+Antigravity stages the plugin under `~/.gemini/antigravity-cli/plugins/geno-tools/` and loads the bundled `skills/` directory. Run `bootstrap.sh` once to put `geno-tools` on PATH.
 
 ### Cursor
 
@@ -191,7 +191,7 @@ How it works in practice:
 1. **Pick your namespace**. Use your company slug as the prefix (`acme-`, `globex-`, etc.). All internal skillsets share that prefix the way public ones share `geno-`.
 2. **Host privately**. Put the repos in your own GitHub Enterprise / GitLab / Bitbucket / private mirror. geno-tools resolves any git URL — there is no central registry it has to call out to.
 3. **Run geno-tools internally**. Pin the upstream OSS release, fork it, or vendor it. The CLI is plain Python, has no telemetry, and the install flow only talks to the git remote you point it at.
-4. **Mix public and private freely**. A developer can run `geno-tools install geno-<name>` (public) alongside `geno-tools install git@github.acme.com:platform/acme-<name>.git` (private) on the same machine. They share `~/.geno-tools/`, the same venv strategy, and the same slash-command surface in Claude Code / Codex / Cursor / Gemini CLI / OpenCode.
+4. **Mix public and private freely**. A developer can run `geno-tools install geno-<name>` (public) alongside `geno-tools install git@github.acme.com:platform/acme-<name>.git` (private) on the same machine. They share `~/.geno-tools/`, the same venv strategy, and the same slash-command surface in Claude Code / Codex / Cursor / Antigravity CLI / OpenCode.
 
 The result: sensitive prompts, datasets, and domain knowledge stay inside the company boundary, while the runtime, the file format, and the multi-agent integrations are the same fast-moving open-source code everyone else uses. You inherit upstream improvements without giving up control of your skill content.
 

--- a/TENETS.md
+++ b/TENETS.md
@@ -2,7 +2,7 @@
 
 Architectural principles that guide all development decisions in geno-tools. When tenets conflict, earlier entries take precedence.
 
-1. **Agent-agnostic** — geno-tools is a package manager that targets all coding agents through platform-specific adapters. It is not a CLI for one agent. Every feature must work across Claude Code, Codex, Gemini CLI, Cursor, and OpenCode.
+1. **Agent-agnostic** — geno-tools is a package manager that targets all coding agents through platform-specific adapters. It is not a CLI for one agent. Every feature must work across Claude Code, Codex, Antigravity CLI, Cursor, and OpenCode.
 
 2. **Skill-system absorption** — external skill formats (Vercel Labs Skills, Superpowers, Ralphy Loop) are first-class import sources, not just inspiration. The plugin structure normalizes them into the `SKILL.md` + `genotools.yaml` contract so skills from any origin are managed the same way.
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -21,10 +21,10 @@ geno-tools is installed as a native plugin on each supported coding CLI:
 - **Claude Code** — `/plugin marketplace add 42euge/geno-tools` then `/plugin install geno-tools@geno-tools`
 - **Codex CLI** — clone + symlink to `~/.agents/skills/geno-tools`
 - **Cursor** — install via plugin manager
-- **Gemini CLI** — `gemini extensions install https://github.com/42euge/geno-tools`
+- **Antigravity CLI** — `agy plugin install https://github.com/42euge/geno-tools`
 - **OpenCode** — add `"geno-tools@git+https://github.com/42euge/geno-tools.git"` to `opencode.json` plugins
 
-Each plugin manifest points at the shared `skills/` directory and the bundled Python package. On Claude Code (SessionStart hook) and OpenCode (plugin loader), the bundled `scripts/bootstrap.sh` self-installs the `geno-tools` shell command onto PATH via `pipx` (with a `pip install --user` fallback) the first time the agent loads the plugin — no separate pipx step. On Gemini CLI / Codex / Cursor, whose plugin formats don't expose a startup hook for arbitrary commands, the install instructions show a one-time `bash <plugin-root>/scripts/bootstrap.sh` invocation. The ecosystem skillsets geno-tools manages are registered with all agents via `npx skills add --agent '*'`.
+Each plugin manifest points at the shared `skills/` directory and the bundled Python package. On Claude Code (SessionStart hook) and OpenCode (plugin loader), the bundled `scripts/bootstrap.sh` self-installs the `geno-tools` shell command onto PATH via `pipx` (with a `pip install --user` fallback) the first time the agent loads the plugin — no separate pipx step. On Antigravity CLI / Codex / Cursor, whose plugin formats don't expose a startup hook for arbitrary commands, the install instructions show a one-time `bash <plugin-root>/scripts/bootstrap.sh` invocation. The ecosystem skillsets geno-tools manages are registered with all agents via `npx skills add --agent '*'`.
 
 ## Source resolution
 
@@ -70,11 +70,10 @@ geno-tools/
 ├── .claude-plugin/plugin.json   # Claude Code plugin manifest
 ├── .codex-plugin/plugin.json    # Codex CLI plugin manifest
 ├── .cursor-plugin/plugin.json   # Cursor plugin manifest
+├── plugin.json                  # Antigravity CLI plugin manifest
 ├── .opencode/                   # OpenCode plugin
 │   ├── plugins/geno-tools.js    #   ES module (registers skills path)
 │   └── INSTALL.md
-├── gemini-extension.json        # Gemini CLI extension descriptor
-├── GEMINI.md                    # Gemini CLI bootstrap context
 ├── package.json                 # npm metadata (OpenCode entry point)
 ├── skills/geno-tools/SKILL.md   # umbrella skill (platform-agnostic)
 ├── commands/                    # slash commands (platform-agnostic)

--- a/docs/docs-home.md
+++ b/docs/docs-home.md
@@ -83,11 +83,11 @@ Compose skills across agents, combine external innovation with private knowledge
     /geno-tools promote geno-<name> exp-1    # merge back to main
     ```
 
-=== "Gemini CLI"
+=== "Antigravity CLI"
 
     ```bash
-    gemini extensions install https://github.com/42euge/geno-tools
-    bash ~/.gemini/extensions/geno-tools/scripts/bootstrap.sh
+    agy plugin install https://github.com/42euge/geno-tools
+    bash ~/.gemini/antigravity-cli/plugins/geno-tools/scripts/bootstrap.sh
 
     /geno-tools ls --available               # see the registry
     /geno-tools install geno-<name>          # install a skillset
@@ -110,7 +110,7 @@ Compose skills across agents, combine external innovation with private knowledge
 :   Uninstall replays install in reverse. No orphaned files, ever.
 
 :material-puzzle-outline: **Agent-agnostic**
-:   Target adapters for Claude Code, geno-cli, Codex, and Gemini CLI.
+:   Target adapters for Claude Code, geno-cli, Codex, and Antigravity CLI.
 
 :material-sync: **Lifecycle-driven**
 :   Every skill follows discover, absorb, evaluate, govern, evolve. The tooling enforces it.

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -55,7 +55,7 @@ discovery.py   normalize  worktrees   audit.md    merge → main
         └──────────────┼──────────────┘
                        │
                  Coding CLIs
-     (Claude Code, Codex, Gemini CLI, Cursor, OpenCode)
+     (Claude Code, Codex, Antigravity CLI, Cursor, OpenCode)
                        │
             geno-agents (coordination)
             geno-msg    (messaging)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,90 +1,65 @@
 # Getting Started
 
-## Prerequisites
+Prerequisites: Git, Node.js for `npx skills`, and Python 3.11+.
 
-- Git
-- Node.js (for `npx skills`)
-- Python 3.11+
+## Install
 
-## Install geno-tools
+Install geno-tools in the coding agent you use. Claude Code and OpenCode run the bootstrap automatically; Antigravity CLI, Codex, and Cursor need the bootstrap once.
 
-geno-tools is installed as a native plugin in your coding agent. Pick the manifest that matches the CLI you use. On Claude Code and OpenCode the plugin's startup hook auto-installs the `geno-tools` shell command onto PATH (via `pipx`, falling back to `pip install --user`); on Gemini CLI / Codex / Cursor you run the same bootstrap script once by hand.
+=== "Claude Code"
+    ```text
+    /plugin marketplace add 42euge/geno-tools
+    /plugin install geno-tools@geno-tools
+    ```
 
-### Claude Code
+=== "Antigravity CLI"
+    ```bash
+    agy plugin install https://github.com/42euge/geno-tools
+    bash ~/.gemini/antigravity-cli/plugins/geno-tools/scripts/bootstrap.sh
+    ```
 
-Inside a Claude Code session:
+=== "Codex CLI"
+    ```text
+    /plugin marketplace add 42euge/geno-tools
+    /plugins
+    ```
 
-```
-/plugin marketplace add 42euge/geno-tools
-/plugin install geno-tools@geno-tools
-```
+    ```bash
+    bash ~/.codex/plugins/cache/geno-tools/geno-tools/*/scripts/bootstrap.sh
+    ```
 
-The first command registers this repo as a marketplace (reads `.claude-plugin/marketplace.json`); the second installs the plugin defined in `.claude-plugin/plugin.json`. The SessionStart hook then runs `scripts/bootstrap.sh`, which materializes `~/.geno/config.yaml` and pipx-installs the `geno-tools` CLI if it isn't already on PATH. Verify with `/plugin list`.
+Verify from inside your agent:
 
-This gives you `/geno-tools install`, `/geno-tools remove`, `/geno-tools ls`, and `/geno-tools update` slash commands inside your coding agent. The command prefix is [user-configurable](skillsets/creating.md#command-prefix-aliasing).
-
-### Gemini CLI
-
-```bash
-gemini extensions install https://github.com/42euge/geno-tools
-bash ~/.gemini/extensions/geno-tools/scripts/bootstrap.sh
-```
-
-The bootstrap step is one-time — Gemini extensions don't expose a startup hook for arbitrary commands, so it has to run by hand.
-
-### Codex CLI / Cursor / OpenCode
-
-See the [README](https://github.com/42euge/geno-tools#install) for the per-agent install snippet. OpenCode runs `scripts/bootstrap.sh` automatically on plugin load; Codex and Cursor need a one-time `bash <plugin-root>/scripts/bootstrap.sh`.
-
-Verify the install by listing the registry from inside your agent:
-
-```
+```text
 /geno-tools ls --available
 ```
 
-## Install your first skillset
+## Install a skillset
 
-List what's available in the registry:
+List available skillsets, then install one:
 
-```
+```text
 /geno-tools ls --available
-```
-
-```
-  geno-agents              https://github.com/42euge/geno-agents.git
-  geno-media               https://github.com/42euge/geno-media.git
-  geno-research            https://github.com/42euge/geno-research.git
-  geno-kaggle              https://github.com/42euge/geno-kaggle.git
-  geno-dev                 https://github.com/42euge/geno-dev.git
-```
-
-Install one:
-
-```
 /geno-tools install geno-<name>
 ```
 
-This clones the repo, sets up any declared venvs, and wires the skill into your coding agent (slash commands appear immediately).
+This clones the repo, prepares any declared venvs, and registers the skill commands in your agent.
 
-## Check what's installed
+Check installed skillsets:
 
-```
+```text
 /geno-tools ls
 ```
 
-```
-  geno-<name>              active: main
-```
+## Develop locally
 
-## Develop a skillset locally
+Link a local checkout instead of cloning:
 
-If you're hacking on a skillset, use `dev` to symlink your local checkout instead of cloning:
-
-```
+```text
 /geno-tools dev geno-<name> ~/src/geno-<name>
 ```
 
-Edits to your local checkout take effect immediately — no reinstall needed.
+Edits take effect immediately.
 
 ## What's next?
 

--- a/docs/javascripts/face.js
+++ b/docs/javascripts/face.js
@@ -29,7 +29,7 @@
 
   // Overview blurb
   var blurb = document.createElement("div");
-  blurb.textContent = "Install, fork, experiment, and promote skillsets for Claude Code, geno-cli, Codex, Gemini CLI, and more — all from one CLI.";
+  blurb.textContent = "Install, fork, experiment, and promote skillsets for Claude Code, geno-cli, Codex, Antigravity CLI, and more — all from one CLI.";
   blurb.style.cssText = "margin-top:1.2rem;font-size:clamp(0.75rem,1.5vw,0.95rem);color:#5c5470;max-width:420px;text-align:center;line-height:1.5;font-family:Inter,-apple-system,system-ui,sans-serif;opacity:0;animation:splash-fade 1.5s ease 1.3s forwards;z-index:1";
   overlay.appendChild(blurb);
 

--- a/docs/onboarding/audit.md
+++ b/docs/onboarding/audit.md
@@ -78,8 +78,8 @@ For enterprise, capture the result as a signed artifact (PR description, interna
 
 ### 7. Multi-agent integration
 
-- [ ] `npx skills add` registers the skill cleanly across all supported agents (Claude Code, Codex, Cursor, Gemini CLI, OpenCode).
-- [ ] Manifests at `.claude-plugin/`, `.codex-plugin/`, `.cursor-plugin/`, `.opencode/`, and `gemini-extension.json` (if shipped) point at the shared `skills/` directory and don't diverge per platform.
+- [ ] `npx skills add` registers the skill cleanly across all supported agents (Claude Code, Codex, Cursor, Antigravity CLI, OpenCode).
+- [ ] Manifests at `.claude-plugin/`, `.codex-plugin/`, `.cursor-plugin/`, `.opencode/`, and `plugin.json` (if shipped) point at the shared `skills/` directory and don't diverge per platform.
 - [ ] Skill activates and produces sane output on at least one supported agent in a fresh install.
 
 ### 8. Documentation

--- a/docs/onboarding/index.md
+++ b/docs/onboarding/index.md
@@ -76,7 +76,7 @@ A skillset is considered onboarded when:
 
 - The audit checklist has been completed and signed off.
 - The repo is reachable from the install path the audience uses (public registry / direct URL / internal mirror).
-- The agent integrations have been verified end-to-end on at least one supported CLI (Claude Code, Codex, Cursor, Gemini CLI, OpenCode).
+- The agent integrations have been verified end-to-end on at least one supported CLI (Claude Code, Codex, Cursor, Antigravity CLI, OpenCode).
 - A clear point of contact is listed in `SKILL.md` metadata.
 
 Anything short of that is "experimental" — fine for `geno-tools dev` and direct-URL installs, not yet fit for the curated registry or an enterprise's approved list.

--- a/docs/skills/geno-agents/index.md
+++ b/docs/skills/geno-agents/index.md
@@ -86,7 +86,7 @@ Multi-agent coordination, registration, autonomous loops
     
     ## Session ID environment variable
     
-    The commands above use `$CLAUDE_SESSION_ID`, which is the session identifier set by Claude Code. Other coding agents (e.g., Gemini CLI, Cursor, Windsurf) may expose their session ID under a different environment variable. The `--session-id` flag accepts any string, so adapt the env var reference to match the agent in use. The Python CLI (`geno_agents/cli.py`) currently falls back to `CLAUDE_SESSION_ID` when no `--session-id` is provided; extending that fallback chain to other agents is tracked as a future improvement.
+    The commands above use `$CLAUDE_SESSION_ID`, which is the session identifier set by Claude Code. Other coding agents (e.g., Antigravity CLI, Cursor, Windsurf) may expose their session ID under a different environment variable. The `--session-id` flag accepts any string, so adapt the env var reference to match the agent in use. The Python CLI (`geno_agents/cli.py`) currently falls back to `CLAUDE_SESSION_ID` when no `--session-id` is provided; extending that fallback chain to other agents is tracked as a future improvement.
     
     ## `.geno-agents` File Format
     

--- a/docs/skills/geno-tools/geno-audit.md
+++ b/docs/skills/geno-tools/geno-audit.md
@@ -177,13 +177,13 @@ Coding agents read repo-level instruction files to understand architecture, entr
 | Agent | Instruction file | Notes |
 |-------|-----------------|-------|
 | Claude Code | `CLAUDE.md` | Read automatically on session start |
-| Gemini CLI | `GEMINI.md` | Pointed to by `gemini-extension.json` via `contextFileName` |
 | OpenAI Codex | `AGENTS.md` | Read automatically on session start |
+| Antigravity CLI | `AGENTS.md` | Read as project-level agent instructions |
 | OpenCode | `.opencode/INSTALL.md` | Plugin-based — context loaded via `.opencode/plugins/` |
 
 ### Single source of truth — `GENO.md`
 
-Rather than maintaining duplicate content across `CLAUDE.md`, `GEMINI.md`, `AGENTS.md`, and OpenCode configs, every geno-* repo should have a single `GENO.md` file at the repo root containing all agent instructions. The per-agent files become thin pointers that import it:
+Rather than maintaining duplicate content across `CLAUDE.md`, `AGENTS.md`, and OpenCode configs, every geno-* repo should have a single `GENO.md` file at the repo root containing all agent instructions. The per-agent files become thin pointers that import it:
 
 ### What goes in `GENO.md`
 
@@ -257,16 +257,6 @@ The per-agent files are thin pointers. No content lives in them — they exist o
 @import GENO.md
 ```
 
-**`gemini-extension.json`** (if present):
-```json
-{
-  "name": "geno-{name}",
-  "description": "...",
-  "version": "0.1.0",
-  "contextFileName": "GEMINI.md"
-}
-```
-
 This way, updating `GENO.md` updates every agent at once. No content lives in the per-agent files — they are pure pointers.
 
 ### Audit checks
@@ -276,9 +266,8 @@ This way, updating `GENO.md` updates every agent at once. No content lives in th
 
 **Recommended:**
 - `CLAUDE.md` exists and contains only `@./GENO.md` (no other content)
-- `GEMINI.md` exists and contains only `@./GENO.md`
 - `AGENTS.md` exists and contains only `@import GENO.md`
-- If `gemini-extension.json` exists, its `contextFileName` points to `GEMINI.md`
+- If `plugin.json` exists, it identifies the Antigravity plugin and keeps skills in the shared `skills/` directory
 - No agent instruction content is duplicated across files — all substance lives in `GENO.md`
 - `GENO.md` contains a Conventions section (a heading matching `Conventions`, case-insensitive)
 - `GENO.md` Conventions section mentions command prefix aliasing — at minimum, states that source files use canonical `geno-` prefixed names for slash commands, not aliased prefixes
@@ -408,7 +397,7 @@ General repo quality checks. None block installation, but they prevent common is
 
 ## Agent-Agnostic Language
 
-The geno ecosystem is CLI-agnostic — skillsets work with Claude Code, Gemini CLI, Codex, OpenCode, and any future coding agent. Documentation and user-facing text must reflect this. Referring to "Claude Code" as if it's the only supported agent misleads users and creates the impression that the skillset is locked to one platform.
+The geno ecosystem is CLI-agnostic — skillsets work with Claude Code, Antigravity CLI, Codex, OpenCode, and any future coding agent. Documentation and user-facing text must reflect this. Referring to "Claude Code" as if it's the only supported agent misleads users and creates the impression that the skillset is locked to one platform.
 
 Use generic terms like "coding agent", "agent session", or "coding CLI" instead of naming a specific agent. When listing prerequisites, mention the supported agents rather than singling one out. When describing how to invoke a skill, show the generic form.
 
@@ -420,14 +409,14 @@ Use generic terms like "coding agent", "agent session", or "coding CLI" instead 
 
 **Prefer:**
 - "Developer skills for AI coding agents"
-- "Prerequisites: a supported coding CLI (Claude Code, Gemini CLI, Codex, or OpenCode)"
+- "Prerequisites: a supported coding CLI (Claude Code, Antigravity CLI, Codex, or OpenCode)"
 - "From within an agent session"
 - "Slash commands" (no agent prefix)
 
 **Do NOT replace** references to agent-specific features, paths, or APIs that are genuinely specific to one agent. For example:
 - `.claude/worktrees/` — this is a real Claude Code directory path, not branding
 - "Codex sandbox" — this is a Codex-specific runtime concept
-- "Gemini CLI extension" — this refers to the actual Gemini extension format
+- "Antigravity CLI plugin" — this refers to the actual Antigravity plugin format
 - Agent-specific plugin manifests (`.claude-plugin/`, `.codex-plugin/`, etc.)
 
 The rule is about how the *skillset itself* is described, not about suppressing legitimate references to agent-specific behavior within skill instructions.

--- a/docs/skills/geno-tools/index.md
+++ b/docs/skills/geno-tools/index.md
@@ -34,7 +34,7 @@ Meta-CLI — install, update, and manage skillsets across all agents
     Orchestrator for the geno-* ecosystem. Manages installation, removal, and updates of skillset repos.
     
     ```!
-    which geno-tools >/dev/null 2>&1 || echo "geno-tools CLI not on PATH. The plugin's SessionStart hook (Claude Code) and OpenCode plugin loader run scripts/bootstrap.sh automatically. On Gemini CLI / Codex / Cursor, run 'bash \$PLUGIN_ROOT/scripts/bootstrap.sh' once (\$PLUGIN_ROOT is e.g. ~/.gemini/extensions/geno-tools)."
+    which geno-tools >/dev/null 2>&1 || echo "geno-tools CLI not on PATH. The plugin's SessionStart hook (Claude Code) and OpenCode plugin loader run scripts/bootstrap.sh automatically. On Antigravity CLI / Codex / Cursor, run 'bash \$PLUGIN_ROOT/scripts/bootstrap.sh' once (\$PLUGIN_ROOT is e.g. ~/.gemini/antigravity-cli/plugins/geno-tools)."
     ```
     
     ## Available Skillsets

--- a/docs/skillsets/creating.md
+++ b/docs/skillsets/creating.md
@@ -202,7 +202,7 @@ The canonical name is the skill's `name` field in frontmatter — use that every
 
 ## Agent-agnostic language
 
-The geno ecosystem is CLI-agnostic — skillsets work with Claude Code, Gemini CLI, Codex, OpenCode, and any future coding agent. Use generic terms like "coding agent" or "agent session" instead of naming a specific agent. When listing prerequisites, mention the supported agents generically.
+The geno ecosystem is CLI-agnostic — skillsets work with Claude Code, Antigravity CLI, Codex, OpenCode, and any future coding agent. Use generic terms like "coding agent" or "agent session" instead of naming a specific agent. When listing prerequisites, mention the supported agents generically.
 
 ## Testing locally
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "geno-tools",
+  "version": "0.2.0",
+  "description": "Meta-CLI for installing and managing geno-* skillsets",
+  "author": {
+    "name": "42euge",
+    "url": "https://github.com/42euge"
+  },
+  "homepage": "https://42euge.github.io/geno-tools",
+  "repository": "https://github.com/42euge/geno-tools",
+  "license": "MIT",
+  "skills": "./skills"
+}

--- a/skills/geno-audit/SKILL.md
+++ b/skills/geno-audit/SKILL.md
@@ -171,13 +171,13 @@ Coding agents read repo-level instruction files to understand architecture, entr
 | Agent | Instruction file | Notes |
 |-------|-----------------|-------|
 | Claude Code | `CLAUDE.md` | Read automatically on session start |
-| Gemini CLI | `GEMINI.md` | Pointed to by `gemini-extension.json` via `contextFileName` |
 | OpenAI Codex | `AGENTS.md` | Read automatically on session start |
+| Antigravity CLI | `AGENTS.md` | Read as project-level agent instructions |
 | OpenCode | `.opencode/INSTALL.md` | Plugin-based — context loaded via `.opencode/plugins/` |
 
 ### Single source of truth — `GENO.md`
 
-Rather than maintaining duplicate content across `CLAUDE.md`, `GEMINI.md`, `AGENTS.md`, and OpenCode configs, every geno-* repo should have a single `GENO.md` file at the repo root containing all agent instructions. The per-agent files become thin pointers that import it:
+Rather than maintaining duplicate content across `CLAUDE.md`, `AGENTS.md`, and OpenCode configs, every geno-* repo should have a single `GENO.md` file at the repo root containing all agent instructions. The per-agent files become thin pointers that import it:
 
 ### What goes in `GENO.md`
 
@@ -251,16 +251,6 @@ The per-agent files are thin pointers. No content lives in them — they exist o
 @import GENO.md
 ```
 
-**`gemini-extension.json`** (if present):
-```json
-{
-  "name": "geno-{name}",
-  "description": "...",
-  "version": "0.1.0",
-  "contextFileName": "GEMINI.md"
-}
-```
-
 This way, updating `GENO.md` updates every agent at once. No content lives in the per-agent files — they are pure pointers.
 
 ### Audit checks
@@ -270,9 +260,8 @@ This way, updating `GENO.md` updates every agent at once. No content lives in th
 
 **Recommended:**
 - `CLAUDE.md` exists and contains only `@./GENO.md` (no other content)
-- `GEMINI.md` exists and contains only `@./GENO.md`
 - `AGENTS.md` exists and contains only `@import GENO.md`
-- If `gemini-extension.json` exists, its `contextFileName` points to `GEMINI.md`
+- If `plugin.json` exists, it identifies the Antigravity plugin and keeps skills in the shared `skills/` directory
 - No agent instruction content is duplicated across files — all substance lives in `GENO.md`
 - `GENO.md` contains a Conventions section (a heading matching `Conventions`, case-insensitive)
 - `GENO.md` Conventions section mentions command prefix aliasing — at minimum, states that source files use canonical `geno-` prefixed names for slash commands, not aliased prefixes
@@ -402,7 +391,7 @@ General repo quality checks. None block installation, but they prevent common is
 
 ## Agent-Agnostic Language
 
-The geno ecosystem is CLI-agnostic — skillsets work with Claude Code, Gemini CLI, Codex, OpenCode, and any future coding agent. Documentation and user-facing text must reflect this. Referring to "Claude Code" as if it's the only supported agent misleads users and creates the impression that the skillset is locked to one platform.
+The geno ecosystem is CLI-agnostic — skillsets work with Claude Code, Antigravity CLI, Codex, OpenCode, and any future coding agent. Documentation and user-facing text must reflect this. Referring to "Claude Code" as if it's the only supported agent misleads users and creates the impression that the skillset is locked to one platform.
 
 Use generic terms like "coding agent", "agent session", or "coding CLI" instead of naming a specific agent. When listing prerequisites, mention the supported agents rather than singling one out. When describing how to invoke a skill, show the generic form.
 
@@ -414,14 +403,14 @@ Use generic terms like "coding agent", "agent session", or "coding CLI" instead 
 
 **Prefer:**
 - "Developer skills for AI coding agents"
-- "Prerequisites: a supported coding CLI (Claude Code, Gemini CLI, Codex, or OpenCode)"
+- "Prerequisites: a supported coding CLI (Claude Code, Antigravity CLI, Codex, or OpenCode)"
 - "From within an agent session"
 - "Slash commands" (no agent prefix)
 
 **Do NOT replace** references to agent-specific features, paths, or APIs that are genuinely specific to one agent. For example:
 - `.claude/worktrees/` — this is a real Claude Code directory path, not branding
 - "Codex sandbox" — this is a Codex-specific runtime concept
-- "Gemini CLI extension" — this refers to the actual Gemini extension format
+- "Antigravity CLI plugin" — this refers to the actual Antigravity plugin format
 - Agent-specific plugin manifests (`.claude-plugin/`, `.codex-plugin/`, etc.)
 
 The rule is about how the *skillset itself* is described, not about suppressing legitimate references to agent-specific behavior within skill instructions.
@@ -429,7 +418,7 @@ The rule is about how the *skillset itself* is described, not about suppressing 
 ### Audit checks
 
 **Recommended:**
-- Scan `README.md`, `docs/**/*.md`, `SKILL.md`, `AGENTS.md`, `GEMINI.md`, and `getting-started.md` for language that frames the skillset as exclusive to one agent
+- Scan `README.md`, `docs/**/*.md`, `SKILL.md`, `AGENTS.md`, and `getting-started.md` for language that frames the skillset as exclusive to one agent
 - Descriptions and headings should use agent-neutral phrasing
 - Prerequisites should list supported CLIs generically, not single out one
 - Do not modify references to agent-specific features, paths, directories, or APIs — only replace branding/framing language

--- a/skills/geno-tools/SKILL.md
+++ b/skills/geno-tools/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 Orchestrator for the geno-* ecosystem. Manages installation, removal, and updates of skillset repos.
 
 ```!
-which geno-tools >/dev/null 2>&1 || echo "geno-tools CLI not on PATH. The plugin's SessionStart hook (Claude Code) and OpenCode plugin loader run scripts/bootstrap.sh automatically. On Gemini CLI / Codex / Cursor, run 'bash \$PLUGIN_ROOT/scripts/bootstrap.sh' once (\$PLUGIN_ROOT is e.g. ~/.gemini/extensions/geno-tools)."
+which geno-tools >/dev/null 2>&1 || echo "geno-tools CLI not on PATH. The plugin's SessionStart hook (Claude Code) and OpenCode plugin loader run scripts/bootstrap.sh automatically. On Antigravity CLI / Codex / Cursor, run 'bash \$PLUGIN_ROOT/scripts/bootstrap.sh' once (\$PLUGIN_ROOT is e.g. ~/.gemini/antigravity-cli/plugins/geno-tools)."
 ```
 
 ## Available Skillsets


### PR DESCRIPTION
## Summary\n- Replace Gemini CLI install/agent wording with Antigravity CLI in user docs and SKILL/GENO guidance.\n- Add root  manifest for Antigravity plugin support and include it in repo layout documentation.\n- Update getting-started, architecture, and ecosystem docs to reflect bootstrap/CLI behavior for Antigravity, while keeping the existing Python CLI and multi-agent architecture intact.\n- Keep changes scoped; no runtime behavior changes.\n\n## Notes\n- Existing  and  are retained as legacy compatibility references.\n