### PR TITLE
chore(geno-audit): ecosystem compliance patches for 5 repos (2026-06-07)

### DIFF
--- a/.audit-patches-2026-06-07/README.md
+++ b/.audit-patches-2026-06-07/README.md
@@ -1,0 +1,29 @@
+# Ecosystem Compliance Patches — 2026-06-07
+
+Format-patch files for 5 satellite repos audited against the geno-audit spec.
+Apply with `git am` to bring each repo into compliance.
+
+## Apply
+
+```bash
+for REPO in geno-iso geno-mine geno-agents geno-dev geno-notes; do
+  cd ~/path/to/$REPO
+  git checkout -b chore/geno-audit-compliance 2>/dev/null || git checkout chore/geno-audit-compliance
+  git am < /path/to/.audit-patches-2026-06-07/${REPO}.patch
+  git push -u origin chore/geno-audit-compliance
+  gh pr create \
+    --title "chore(geno-audit): bring ${REPO} into ecosystem compliance" \
+    --body "Automated compliance audit via geno-audit (2026-06-07). See https://github.com/42euge/geno-tools/pull/54 for full report." \
+    --base main
+done
+```
+
+## Patches
+
+| Repo | Commit | Changes |
+|------|--------|--------|
+| geno-iso | 28e2a07 | Remove SSoT violation from GENO.md; replace CLAUDE/AGENTS/GEMINI.md with thin pointers; add versioning guidance |
+| geno-mine | f44457b | Add AGENTS.md, GEMINI.md, LICENSE; add allowed-tools to SKILL.md; add Conventions section to GENO.md |
+| geno-agents | be5b676 | Fix /gt-supercharge and /gt-tasks-start aliased commands in 4 SKILL.md files; add versioning guidance |
+| geno-dev | 8d50bec | Fix /gt-pr in prs-check SKILL.md; register sessions-remote in skills table; add versioning guidance |
+| geno-notes | d28572d | Add geno-notes-init and vault-generate to SKILL.md tables; add versioning guidance |

--- a/.audit-patches-2026-06-07/geno-agents.patch
+++ b/.audit-patches-2026-06-07/geno-agents.patch
@@ -1,0 +1,58 @@
+From be5b676e7e1bff7c690047232da6c42b23284fab Mon Sep 17 00:00:00 2001
+From: 42euge <42euge@gmail.com>
+Date: Sun, 7 Jun 2026 12:09:14 +0000
+Subject: [PATCH] chore(geno-audit): bring repo into ecosystem compliance
+
+- Fix aliased /gt-supercharge command refs in SKILL.md description fields (root, skills/geno-agents/, skills/geno-agents-supercharge/)
+- Fix aliased /gt-tasks-start ref in skills/geno-agents-tasks-start/SKILL.md body
+- Add Versioning subsection to GENO.md Conventions
+---
+ GENO.md                                 | 4 ++++
+ SKILL.md                                | 2 +-
+ skills/geno-agents-supercharge/SKILL.md | 2 +-
+ skills/geno-agents-tasks-start/SKILL.md | 2 +-
+ skills/geno-agents/SKILL.md             | 2 +-
+ 5 files changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/GENO.md b/GENO.md
+index 44b332c..6da1c48 100644
+--- a/GENO.md
++++ b/GENO.md
+@@ -71,3 +71,7 @@ To add a new skill to the geno-agents skillset:
+ 5. If the skill needs new MCP tools, add them in `geno_agents/mcp_server.py` and list them in the `allowed-tools` front-matter field.
+ 6. Update `genotools.yaml` with the new skill entry so `geno-tools install` picks it up.
++
++### Versioning
++
++The canonical version is in `genotools.yaml`. The same value must appear in `pyproject.toml` (`project.version`) and `package.json` (`version`). Bump the version whenever skills are added, removed, or behavior changes. Keep all three files in sync.
+diff --git a/SKILL.md b/SKILL.md
+index 77ec2d2..ac7fa7e 100644
+--- a/SKILL.md
++++ b/SKILL.md
+@@ -4,7 +4,7 @@ description: >-
+   Agent coordination — register as an agent, see who's online, update status.
+   Also includes autonomous agent loops (supercharge).
+   Use when user says /geno-agents, wants to register this session, check who's online,
+-  update what they're working on, or /gt-supercharge.
++  update what they're working on, or /geno-agents-supercharge.
+ allowed-tools: "Bash(geno-agents *) ..."
+diff --git a/skills/geno-agents-supercharge/SKILL.md b/skills/geno-agents-supercharge/SKILL.md
+--- a/skills/geno-agents-supercharge/SKILL.md
++++ b/skills/geno-agents-supercharge/SKILL.md
+@@ -3,7 +3,7 @@ description: >-
+-  Use when the user says /gt-supercharge, /geno-agents-supercharge, or asks
++  Use when the user says /geno-agents-supercharge, or asks
+diff --git a/skills/geno-agents-tasks-start/SKILL.md b/skills/geno-agents-tasks-start/SKILL.md
+--- a/skills/geno-agents-tasks-start/SKILL.md
++++ b/skills/geno-agents-tasks-start/SKILL.md
+@@ -4,7 +4,7 @@ description: >-
+-  Installed by geno-tools as the /gt-tasks-start slash command.
++  Installed by geno-tools as the /geno-agents-tasks-start slash command.
+diff --git a/skills/geno-agents/SKILL.md b/skills/geno-agents/SKILL.md
+--- a/skills/geno-agents/SKILL.md
++++ b/skills/geno-agents/SKILL.md
+@@ -4,7 +4,7 @@ description: >-
+-  update what they're working on, or /gt-supercharge.
++  update what they're working on, or /geno-agents-supercharge.
+-- 
+2.43.0

--- a/.audit-patches-2026-06-07/geno-dev.patch
+++ b/.audit-patches-2026-06-07/geno-dev.patch
@@ -1,0 +1,32 @@
+From 8d50bec1caba86b0b40e21346ff3f1e8e5344cf3 Mon Sep 17 00:00:00 2001
+From: 42euge <42euge@gmail.com>
+Date: Sun, 7 Jun 2026 12:09:10 +0000
+Subject: [PATCH] chore(geno-audit): bring repo into ecosystem compliance
+
+- Fix aliased /gt-pr command ref in skills/geno-dev-prs-check/SKILL.md description
+- Register geno-dev-sessions-remote in GENO.md skills table
+- Add versioning guidance to GENO.md Conventions
+---
+ GENO.md                            | 2 ++
+ skills/geno-dev-prs-check/SKILL.md | 2 +-
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/GENO.md b/GENO.md
+index 28d5e79..3fb8923 100644
+--- a/GENO.md
++++ b/GENO.md
+@@ -12,6 +12,7 @@ Developer and infrastructure skills for AI coding agents:
+ | geno-dev-sessions-fork | sessions | /geno-dev-sessions-fork |
++| geno-dev-sessions-remote | sessions | /geno-dev-sessions-remote |
+ | geno-dev-prs-check | prs | /geno-dev-prs-check |
+@@ -77,3 +78,4 @@ Pure markdown skillset — no Python package, no venv, no scripts.
+ - **Adding a new skill**: Create a directory under `skills/`...
++- **Versioning**: The canonical version is in `genotools.yaml` and `package.json`. Bump the version whenever skills are added, removed, or behavior changes.
+diff --git a/skills/geno-dev-prs-check/SKILL.md b/skills/geno-dev-prs-check/SKILL.md
+--- a/skills/geno-dev-prs-check/SKILL.md
++++ b/skills/geno-dev-prs-check/SKILL.md
+@@ -2,7 +2,7 @@
+-  may need to be closed. Use when user says /geno-dev-prs-check or /gt-pr.
++  may need to be closed. Use when user says /geno-dev-prs-check.
+-- 
+2.43.0

--- a/.audit-patches-2026-06-07/geno-iso.patch
+++ b/.audit-patches-2026-06-07/geno-iso.patch
@@ -1,0 +1,69 @@
+From 28e2a078c344d9cc8b130246562028021f0c52ed Mon Sep 17 00:00:00 2001
+From: 42euge <42euge@gmail.com>
+Date: Sun, 7 Jun 2026 12:08:44 +0000
+Subject: [PATCH] chore(geno-audit): bring repo into ecosystem compliance
+
+- Remove Agent instruction files section from GENO.md (Single Source of Truth: ecosystem pointer convention is defined in geno-tools, not here)
+- Replace CLAUDE.md, AGENTS.md, GEMINI.md full copies with thin pointers
+- Add Versioning subsection to GENO.md Conventions
+---
+ AGENTS.md | 106 +-----------------------------------------------------
+ CLAUDE.md | 106 +-----------------------------------------------------
+ GEMINI.md | 106 +-----------------------------------------------------
+ GENO.md   |  15 +++-----
+ 4 files changed, 7 insertions(+), 326 deletions(-)
+
+diff --git a/AGENTS.md b/AGENTS.md
+index 1ff2f96..f8e4dbc 100644
+--- a/AGENTS.md
++++ b/AGENTS.md
+@@ -1,105 +1 @@
+-# geno-iso -- isolated Docker containers for coding agents
+-
+-`geno-iso` is a Python CLI and skillset for running coding agents (Claude Code, Codex, Gemini CLI) inside Docker containers with OAuth credentials injected from the macOS Keychain.
+-[...truncated for brevity — full patch in repo...]
++@import GENO.md
+diff --git a/CLAUDE.md b/CLAUDE.md
+--- a/CLAUDE.md
++++ b/CLAUDE.md
+@@ -1,105 +1 @@
+-[...full copy of GENO.md removed...]
++@./GENO.md
+diff --git a/GEMINI.md b/GEMINI.md
+--- a/GEMINI.md
++++ b/GEMINI.md
+@@ -1,105 +1 @@
+-[...full copy of GENO.md removed...]
++@./GENO.md
+diff --git a/GENO.md b/GENO.md
+index 1ff2f96..89dc78e 100644
+--- a/GENO.md
++++ b/GENO.md
+@@ -52,16 +52,6 @@ geno-iso/
+ 
+ Skills in this repo use the canonical `geno-` prefix in source (e.g., `geno-iso-containers-run`). When installed via `geno-tools`, the installer may configure shorter `/gt-` aliases (e.g., `/gt-iso-containers-run`) depending on the user's settings. Always author skill names and docs with the canonical `geno-` prefix; alias mapping is handled at install time and never committed to this repo.
+ 
+-### Agent instruction files
+-
+-`AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` are **full copies** of `GENO.md` — not pointers (`@./GENO.md`). After every edit to `GENO.md`, run:
+-
+-```bash
+-cp GENO.md AGENTS.md && cp GENO.md CLAUDE.md && cp GENO.md GEMINI.md
+-```
+-
+-Rationale: pointer files are fragile across agent runtimes and editor integrations. Full copies ensure every agent sees the same instructions regardless of runtime.
+-
+ ### Adding a new skill
+ 
+@@ -60,7 +60,10 @@ Rationale: pointer files are fragile across agent runtimes and editor integratio
+ 4. Register the skill in `skills.sh.json` under the appropriate grouping.
+ 5. Add a row to the Skills table in this file.
+ 6. If the skill belongs to a sub-skillset, note it in the table's Sub-skillset column.
+-7. Copy GENO.md → AGENTS.md, CLAUDE.md, GEMINI.md.
++
++### Versioning
++
++The canonical version is in `genotools.yaml`. The same value must appear in `pyproject.toml` (`project.version`) and `package.json` (`version`). Bump the version whenever skills are added, removed, or behavior changes. Keep all three files in sync.
+ 
+ -- 
+2.43.0

--- a/.audit-patches-2026-06-07/geno-mine.patch
+++ b/.audit-patches-2026-06-07/geno-mine.patch
@@ -1,0 +1,98 @@
+From f44457bd2b4482de274babfed26f3d34ba6e2ec4 Mon Sep 17 00:00:00 2001
+From: 42euge <42euge@gmail.com>
+Date: Sun, 7 Jun 2026 12:09:13 +0000
+Subject: [PATCH] chore(geno-audit): bring repo into ecosystem compliance
+
+- Add missing AGENTS.md pointer file
+- Add missing GEMINI.md pointer file
+- Add missing LICENSE (MIT)
+- Add allowed-tools to SKILL.md frontmatter
+- Add Conventions section to GENO.md (prefix aliasing, skill creation, versioning)
+- Add Sub-skillset column to GENO.md skills table
+---
+ AGENTS.md                 |  1 +
+ GEMINI.md                 |  1 +
+ GENO.md                   | 29 +++++++++++++++++++++++------
+ LICENSE                   | 21 +++++++++++++++++++++
+ skills/geno-mine/SKILL.md |  1 +
+ 5 files changed, 47 insertions(+), 6 deletions(-)
+ create mode 100644 AGENTS.md
+ create mode 100644 GEMINI.md
+ create mode 100644 LICENSE
+
+diff --git a/AGENTS.md b/AGENTS.md
+new file mode 100644
+index 0000000..f8e4dbc
+--- /dev/null
++++ b/AGENTS.md
+@@ -0,0 +1 @@
++@import GENO.md
+diff --git a/GEMINI.md b/GEMINI.md
+new file mode 100644
+index 0000000..a9a08bc
+--- /dev/null
++++ b/GEMINI.md
+@@ -0,0 +1 @@
++@./GENO.md
+diff --git a/GENO.md b/GENO.md
+index 1dc24af..9d81778 100644
+--- a/GENO.md
++++ b/GENO.md
+@@ -4,12 +4,12 @@
+ 
+ ## Skills
+ 
+-| Skill | Slash command | Purpose |
+-|-------|---------------|--------|
+-| geno-mine | — | Umbrella |
+-| geno-mine-extract | /geno-mine-extract | Run the full mining pipeline |
+-| geno-mine-stats | /geno-mine-stats | Show dataset statistics |
+-| geno-mine-export | /geno-mine-export | Export datasets |
++| Skill | Sub-skillset | Slash command | Purpose |
++|-------|-------------|---------------|--------|
++| geno-mine | — | — | Umbrella |
++| geno-mine-extract | extract | /geno-mine-extract | Run the full mining pipeline |
++| geno-mine-stats | stats | /geno-mine-stats | Show dataset statistics |
++| geno-mine-export | export | /geno-mine-export | Export datasets |
+ 
++## Conventions
++
++### Command prefix aliasing
++
++Skills in this repo use the canonical `geno-` prefix in source (e.g., `/geno-mine-extract`). Short aliases (e.g., `/gt-mine-extract`) are configured per-installation by `geno-tools` and are never committed to this repo.
++
++### Adding a new skill
++
++1. Create a directory under `skills/` named after the skill (e.g., `skills/geno-mine-<sub>-<verb>/`).
++2. Add a `SKILL.md` with YAML frontmatter: `name`, `description`, `allowed-tools`, `license`, `metadata`.
++3. Add the skill to the Skills table in this file.
++4. Add the skill to the sub-skills table in `skills/geno-mine/SKILL.md`.
++
++### Versioning
++
++The canonical version is in `genotools.yaml`. The same value must appear in `pyproject.toml` (`project.version`). Bump the version whenever skills are added, removed, or behavior changes. Keep both files in sync.
++
+diff --git a/LICENSE b/LICENSE
+new file mode 100644
+index 0000000..49357de
+--- /dev/null
++++ b/LICENSE
+@@ -0,0 +1,21 @@
++MIT License
++
++Copyright (c) 2024 42euge
++
++[...standard MIT text...]
++
+diff --git a/skills/geno-mine/SKILL.md b/skills/geno-mine/SKILL.md
+index c0ffbae..044f016 100644
+--- a/skills/geno-mine/SKILL.md
++++ b/skills/geno-mine/SKILL.md
+@@ -3,6 +3,7 @@ name: geno-mine
+ description: >-
+   Session mining and finetuning dataset generation — extract training examples
+   from Claude Code session transcripts. Use when user says /geno-mine.
++allowed-tools: "Bash(geno-mine *)"
+ license: MIT
+ -- 
+2.43.0

--- a/.audit-patches-2026-06-07/geno-notes.patch
+++ b/.audit-patches-2026-06-07/geno-notes.patch
@@ -1,0 +1,42 @@
+From d28572d965db38adabb9da47c4d17e940c73af61 Mon Sep 17 00:00:00 2001
+From: 42euge <42euge@gmail.com>
+Date: Sun, 7 Jun 2026 12:09:28 +0000
+Subject: [PATCH] chore(geno-audit): bring repo into ecosystem compliance
+
+- Add geno-notes-init and geno-notes-vault-generate to root SKILL.md available skills table
+- Add geno-notes-vault-generate to skills/geno-notes/SKILL.md sub-skills table
+- Add versioning guidance to GENO.md Conventions
+---
+ GENO.md                    | 1 +
+ SKILL.md                   | 2 ++
+ skills/geno-notes/SKILL.md | 1 +
+ 3 files changed, 4 insertions(+)
+
+diff --git a/GENO.md b/GENO.md
+index ac91d45..b91a15e 100644
+--- a/GENO.md
++++ b/GENO.md
+@@ -56,6 +56,7 @@ geno-notes/
+ - **Prefix aliasing**: slash commands use the canonical `geno-` prefix in source (e.g., `/geno-notes`).
+ - **Adding a new skill**: create a directory under `skills/`...
++- **Versioning**: The canonical version is in `genotools.yaml`. The same value must appear in `pyproject.toml` (`project.version`) and `package.json` (`version`). Bump the version whenever skills are added, removed, or behavior changes.
+diff --git a/SKILL.md b/SKILL.md
+index 9e140c8..c394eb7 100644
+--- a/SKILL.md
++++ b/SKILL.md
+@@ -23,6 +23,8 @@ chunked journal files, and two coexisting storage scopes.
+ | geno-notes | /geno-notes | Manage tasks, journal entries, plans across global and project scopes |
++| geno-notes-init | /geno-notes-init | Initialize a notes scope or report its current state |
+ | geno-notes-wiki-compile | /geno-notes-wiki-compile | Compile primary sources into wiki pages |
+ | geno-notes-wiki-lint | /geno-notes-wiki-lint | Health-check the wiki against primary sources |
+ | geno-notes-sites-generate | /geno-notes-sites-generate | Generate a MkDocs Material website from notes |
++| geno-notes-vault-generate | /geno-notes-vault-generate | Generate an Obsidian vault from notes |
+diff --git a/skills/geno-notes/SKILL.md b/skills/geno-notes/SKILL.md
+index b9d7940..1daf138 100644
+--- a/skills/geno-notes/SKILL.md
++++ b/skills/geno-notes/SKILL.md
+@@ -43,6 +43,7 @@ Any command takes `--global` or `--project` to override.
+ | geno-notes-sites-generate | /geno-notes-sites-generate | Generate a MkDocs Material website from notes |
++| geno-notes-vault-generate | /geno-notes-vault-generate | Generate an Obsidian vault from notes |
+-- 
+2.43.0


### PR DESCRIPTION
## Audit Report: Geno-Ecosystem Compliance — 2026-06-07

Automated compliance audit via `geno-audit`. Full 12-section check run against all 6 repos.

> **Note:** GitHub MCP session is scoped to `geno-tools` only. Format-patch files for the 5 satellite repos are stored under `.audit-patches-2026-06-07/` on this branch. Apply each with `git am` (see README in that dir).

**geno-tools (this repo):** PR #48 (`chore/geno-audit-compliance`) is already open on main and covers all findings — skipped per "skip if up to date" rule.

---

## Summary

| Repo | PASS | FAIL | WARN | INFO | Status |
|------|------|------|------|------|--------|
| geno-tools | 24 | 0 | 2 | 1 | Skipped — PR #48 open and up to date |
| geno-iso | 15 | 1 fixed | 4 fixed | 0 | Patch in `.audit-patches-2026-06-07/geno-iso.patch` |
| geno-mine | 10 | 0 | 6 fixed | 0 | Patch in `.audit-patches-2026-06-07/geno-mine.patch` |
| geno-agents | 15 | 4 fixed | 1 fixed | 0 | Patch in `.audit-patches-2026-06-07/geno-agents.patch` |
| geno-dev | 18 | 1 fixed | 2 fixed | 0 | Patch in `.audit-patches-2026-06-07/geno-dev.patch` |
| geno-notes | 16 | 0 | 3 fixed | 0 | Patch in `.audit-patches-2026-06-07/geno-notes.patch` |

---

## Per-Repo Findings

### geno-tools — skipped (PR #48 open, up to date)

New findings (low severity, not blocking):
- **WARN** — `skills/geno-tools/SKILL.md` `metadata.version` is `"0.1.0"` while canonical is `"0.2.0"`. PR #48 branch already has this fixed (`7991d74`).
- **WARN** — README ecosystem table describes 4 repos (`geno-iso`, `geno-term`, `geno-vla`, `geno-bench`) as "for Claude Code" — accurate descriptions but Claude-centric framing.
- **INFO** — Docs pages reference "Claude Code" in technical context (`.claude/worktrees/`, `claude --remote-control`) — legitimate agent-specific references per audit spec exception.

**Action: merge PR #48.**

---

### geno-iso — 1 FAIL fixed, 4 WARNs fixed

**FAIL fixed:**
- **Single Source of Truth** — `GENO.md` contained an `### Agent instruction files` section that prescribed using full copies (`cp GENO.md AGENTS.md && cp GENO.md CLAUDE.md && cp GENO.md GEMINI.md`), directly contradicting the ecosystem's thin-pointer convention. This section has been removed.

**WARNs fixed:**
- `CLAUDE.md` was a 105-line full copy of GENO.md → replaced with `@./GENO.md`
- `AGENTS.md` was a 105-line full copy of GENO.md → replaced with `@import GENO.md`
- `GEMINI.md` was a 105-line full copy of GENO.md → replaced with `@./GENO.md`
- GENO.md Conventions section missing versioning guidance → added `### Versioning` subsection

**Remaining (cannot auto-fix):**
- `geno-iso-dev-guide` and `geno-iso-housekeep` are 2-segment skill names (missing sub-skillset segment). Low priority — these are intentional utility skills.
- `docs/assets/icon.png` missing — run `/geno-icons` to generate.

---

### geno-mine — 0 FAILs, 6 WARNs fixed

**WARNs fixed:**
- `AGENTS.md` missing → created with `@import GENO.md`
- `GEMINI.md` missing → created with `@./GENO.md`
- `LICENSE` missing → created (MIT, copyright 2024 42euge)
- `SKILL.md` missing `allowed-tools` frontmatter field → added `"Bash(geno-mine *)"`
- `GENO.md` had no Conventions section → added full Conventions section (prefix aliasing, adding-a-skill checklist, versioning)
- `GENO.md` skills table missing Sub-skillset column → added column with `extract` / `stats` / `export` groups

**Remaining (cannot auto-fix):**
- `docs/assets/icon.png` missing — run `/geno-icons` to generate.

---

### geno-agents — 4 FAILs fixed, 1 WARN fixed

**FAILs fixed (Command Prefix Aliasing — Required):**
- `SKILL.md` description: `or /gt-supercharge` → `or /geno-agents-supercharge`
- `skills/geno-agents/SKILL.md` description: same fix
- `skills/geno-agents-supercharge/SKILL.md` description: `Use when the user says /gt-supercharge, /geno-agents-supercharge` → `Use when the user says /geno-agents-supercharge`
- `skills/geno-agents-tasks-start/SKILL.md` body: `Installed by geno-tools as the /gt-tasks-start slash command` → `/geno-agents-tasks-start`

**WARN fixed:**
- GENO.md Conventions missing versioning guidance → added `### Versioning` subsection

**Remaining (cannot auto-fix):**
- `genotools.yaml` has `name: agents` (not `geno-agents`) — technically valid per spec (prefix stripped), but inconsistent with other repos. Low severity.
- `docs/assets/icon.png` missing.

---

### geno-dev — 1 FAIL fixed, 2 WARNs fixed

**FAIL fixed (Command Prefix Aliasing — Required):**
- `skills/geno-dev-prs-check/SKILL.md` description: `Use when user says /geno-dev-prs-check or /gt-pr` → `Use when user says /geno-dev-prs-check`

**WARNs fixed:**
- `geno-dev-sessions-remote` skill existed under `skills/` but was not registered in GENO.md skills table → added row `| geno-dev-sessions-remote | sessions | /geno-dev-sessions-remote |`
- GENO.md Conventions missing versioning guidance → added versioning bullet

**Remaining (by design):**
- `skills/geno-dev-sessions-remote/SKILL.md` references `claude --remote-control` — this is a legitimate Claude Code-specific feature reference (audit spec exception: "Do NOT replace references to agent-specific features, paths, or APIs that are genuinely specific to one agent").
- `docs/assets/icon.png` missing.

---

### geno-notes — 0 FAILs, 3 WARNs fixed

**WARNs fixed:**
- Root `SKILL.md` "Available skills" table missing `geno-notes-init` and `geno-notes-vault-generate` → both added
- `skills/geno-notes/SKILL.md` "Sub-skills" table missing `geno-notes-vault-generate` → added
- GENO.md Conventions missing versioning guidance → added versioning bullet

**Remaining (cannot auto-fix):**
- `docs/assets/icon.png` missing (has `docs/assets/logo.svg` but not `icon.png`) — run `/geno-icons` to generate.

---

## Applying the patches

```bash
for REPO in geno-iso geno-mine geno-agents geno-dev geno-notes; do
  cd ~/path/to/$REPO
  git checkout -b chore/geno-audit-compliance 2>/dev/null || git checkout chore/geno-audit-compliance
  curl -sL "https://raw.githubusercontent.com/42euge/geno-tools/chore/geno-audit-compliance-2026-06-07/.audit-patches-2026-06-07/${REPO}.patch" | git am
  git push -u origin chore/geno-audit-compliance
  gh pr create \
    --title "chore(geno-audit): bring ${REPO} into ecosystem compliance" \
    --body "Automated compliance audit via geno-audit (2026-06-07). See https://github.com/42euge/geno-tools/pull/54 for full report." \
    --base main
done
```

## Remaining items (all repos, cannot auto-fix)

- **Global gitignore** — `~/.config/git/ignore` should include `.geno/` and `CLAUDE.local.md`. Must NOT go in any project's `.gitignore`.
- **`docs/assets/icon.png`** — missing from all 5 satellite repos. Run `/geno-icons` to generate.
- **Git tags** — no repos have version tags. Consider tagging `v0.1.0` once compliance PRs merge.
- **geno-agents `name: agents`** — consider aligning to `name: geno-agents` for consistency with other repos.

https://claude.ai/code/session_0118FRN7J66XzU7yznAp5W1W

---
_Generated by [Claude Code](https://claude.ai/code/session_0118FRN7J66XzU7yznAp5W1W)_