### PR TITLE
chore(geno-audit): satellite repo compliance patches 2026-06-12

### DIFF
--- a/.audit-patches-2026-06-12/README.md
+++ b/.audit-patches-2026-06-12/README.md
@@ -1,0 +1,50 @@
+# Satellite Repo Compliance Patches — 2026-06-12
+
+Automated compliance audit via `geno-audit`. All 5 satellite repos audited against the full
+12-section spec in `skills/geno-audit/SKILL.md`. Apply each patch with:
+
+```bash
+git clone https://github.com/42euge/<repo>
+cd <repo>
+git checkout -b chore/geno-audit-compliance
+git am .audit-patches-2026-06-12/<repo>.patch
+git push -u origin chore/geno-audit-compliance
+# then open PR on GitHub
+```
+
+## Audit Summary
+
+| Repo | PASS | FAIL | WARN | INFO | Key fixes |
+|------|------|------|------|------|-----------|
+| geno-iso | 34 | 0 | 5 fixed | 1 | CLAUDE/AGENTS/GEMINI.md → thin pointers; GENO.md SSOT violations removed; /gt- prefix fixed; versioning subsection added |
+| geno-mine | 9 | 0 | 11 fixed | 1 | AGENTS.md + GEMINI.md + LICENSE created; Conventions section added to GENO.md; agent-agnostic language; geno-mine-backfill SKILL.md created |
+| geno-agents | 8 | 3 fixed | 4 fixed | 1 | .geno-agents untracked; genotools.yaml name "agents"→"geno-agents"; /gt- aliases fixed in 5 SKILL.md files; versioning guidance added |
+| geno-dev | 9 | 1 fixed | 8 (4 fixed) | 1 | /gt-pr alias removed; stale loop skills removed from SKILL.md; sessions-remote added to GENO.md + SKILL.md + README; versioning added; .geno-agents untracked |
+| geno-notes | 9 | 2 fixed | 2 (1 fixed) | 1 | __version__ synced 0.2.0→0.1.0; 4 sub-skillset SKILL.md dirs created (tasks, inbox, search, workspace); GENO.md + SKILL.md updated; versioning guidance added |
+
+## Patch Details
+
+| Repo | Patch file | Lines |
+|------|-----------|-------|
+| geno-iso | geno-iso.patch | 402 |
+| geno-mine | geno-mine.patch | 276 |
+| geno-agents | geno-agents.patch | 167 (2 commits) |
+| geno-dev | geno-dev.patch | 187 (2 commits) |
+| geno-notes | geno-notes.patch | 450 |
+
+## Unfixable items (require manual action)
+
+- **All repos — Section 1 INFO**: Global gitignore (`~/.config/git/ignore`) does not exist on this machine. Add `.geno/` and `CLAUDE.local.md` there:
+  ```bash
+  git config --global core.excludesFile ~/.config/git/ignore
+  printf '.geno/\nCLAUDE.local.md\n' >> ~/.config/git/ignore
+  ```
+  Per audit spec, these must NOT be added to any project's `.gitignore`.
+
+- **geno-dev — Section 1 WARN**: Same global gitignore issue as above.
+
+- **geno-dev — Section 5 INFO**: geno-dev-sessions-remote is now in GENO.md/SKILL.md/README but the
+  umbrella `skills/geno-dev/SKILL.md` commands list was not updated (intentionally curated scope).
+
+- **geno-notes — Section 7 INFO**: `docs/assets/icon.png` missing (has `logo.svg` only). Generate
+  via `/geno-icons` when needed.

--- a/.audit-patches-2026-06-12/geno-agents.patch
+++ b/.audit-patches-2026-06-12/geno-agents.patch
@@ -1,0 +1,167 @@
+From e13f18afb0fa34da51144d590518fb16372073fd Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 12 Jun 2026 00:12:19 +0000
+Subject: [PATCH 1/2] chore(geno-audit): bring repo into ecosystem compliance
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+- Fix genotools.yaml: rename `name: agents` → `name: geno-agents` to match repo directory
+- Fix command prefix aliasing: replace all /gt-* slash command references with canonical /geno-* form
+  - SKILL.md (root): /gt-supercharge → /geno-agents-supercharge
+  - skills/geno-agents/SKILL.md: same fix
+  - skills/geno-agents-supercharge/SKILL.md: /gt-supercharge and cross-skillset refs
+  - skills/geno-agents-tasks-start/SKILL.md: /gt-tasks-start → /geno-agents-tasks-start
+  - GENO.md Prefix aliasing section: remove hardcoded /gt- example
+- Add versioning guidance to GENO.md Conventions section (required by audit spec)
+---
+ GENO.md                                 | 7 ++++++-
+ SKILL.md                                | 2 +-
+ genotools.yaml                          | 2 +-
+ skills/geno-agents-supercharge/SKILL.md | 6 +++---
+ skills/geno-agents-tasks-start/SKILL.md | 2 +-
+ skills/geno-agents/SKILL.md             | 2 +-
+ 6 files changed, 13 insertions(+), 8 deletions(-)
+
+diff --git a/GENO.md b/GENO.md
+index 44b332c..76fa508 100644
+--- a/GENO.md
++++ b/GENO.md
+@@ -59,7 +59,7 @@ Projects declare agent identity via a `.geno-agents` YAML file at the repo root.
+ 
+ ### Prefix aliasing
+ 
+-Source code and documentation use the canonical `geno-` prefix (e.g., `geno-agents`, `/geno-agents-supercharge`). Short `/gt-` aliases (e.g., `/gt-supercharge`, `/gt-agents`) are configured per-install by `geno-tools` and are not defined in this repo. When adding new skills or commands, always use the canonical `geno-agents` prefix; the installer handles alias generation.
++Source code and documentation use the canonical `geno-` prefix (e.g., `geno-agents`, `/geno-agents-supercharge`). Per-install aliases are configured via `command_prefix` in `~/.geno/config.yaml` and applied at install time by `geno-tools` — they are not defined in this repo. When adding new skills or commands, always use the canonical `geno-agents` prefix; the installer handles alias generation.
+ 
+ ### Adding a new skill
+ 
+@@ -71,3 +71,8 @@ To add a new skill to the geno-agents skillset:
+ 4. If the skill needs new CLI subcommands, add them in `geno_agents/cli.py`.
+ 5. If the skill needs new MCP tools, add them in `geno_agents/mcp_server.py` and list them in the `allowed-tools` front-matter field.
+ 6. Update `genotools.yaml` with the new skill entry so `geno-tools install` picks it up.
++7. Bump the version in `genotools.yaml`, `pyproject.toml`, and `package.json` (all three must stay in sync).
++
++### Versioning
++
++The canonical version lives in `genotools.yaml` (`version` field). The same version must appear in `pyproject.toml` (`project.version`) and `package.json` (`version`). Bump the version whenever skills are added, removed, or behavior changes. Keep all three files in sync.
+diff --git a/SKILL.md b/SKILL.md
+index 77ec2d2..ac7fa7e 100644
+--- a/SKILL.md
++++ b/SKILL.md
+@@ -4,7 +4,7 @@ description: >-
+   Agent coordination — register as an agent, see who's online, update status.
+   Also includes autonomous agent loops (supercharge).
+   Use when user says /geno-agents, wants to register this session, check who's online,
+-  update what they're working on, or /gt-supercharge.
++  update what they're working on, or /geno-agents-supercharge.
+ allowed-tools: "Bash(geno-agents *) mcp__geno-agents__list_agents mcp__geno-agents__who mcp__geno-agents__whois mcp__geno-agents__update_agent mcp__geno-agents__register_agent"
+ argument-hint: "[who|whois|ls|register|update|status] [args...]"
+ license: MIT
+diff --git a/genotools.yaml b/genotools.yaml
+index af44b62..b142fbb 100644
+--- a/genotools.yaml
++++ b/genotools.yaml
+@@ -1,4 +1,4 @@
+-name: agents
++name: geno-agents
+ version: "0.1.0"
+ description: "Agent coordination layer — registration, discovery, and presence for multi-agent systems"
+ 
+diff --git a/skills/geno-agents-supercharge/SKILL.md b/skills/geno-agents-supercharge/SKILL.md
+index b8962cd..58a8dc2 100644
+--- a/skills/geno-agents-supercharge/SKILL.md
++++ b/skills/geno-agents-supercharge/SKILL.md
+@@ -3,7 +3,7 @@ name: geno-agents-supercharge
+ description: >-
+   Run an extended autonomous work session across benchmark tasks with
+   structured cycles of implementation, reflection, and research.
+-  Use when the user says /gt-supercharge, /geno-agents-supercharge, or asks
++  Use when the user says /geno-agents-supercharge or asks
+   for a long-running autonomous run across tasks.
+ disable-model-invocation: true
+ argument-hint: "[duration] [scope]  e.g. 'go!', '4h change_blindness', '12h all'"
+@@ -81,7 +81,7 @@ Three specialized agent roles cycle through work:
+ - Writes a brief handoff note to `checkpoints/impl_<cycle>.md`
+ 
+ ### Evaluator (runs every 2-3 cycles)
+-- Pulls latest results from Kaggle using `/gt-kaggle-benchmarks-task-review`
++- Pulls latest results from Kaggle using `/geno-kaggle-benchmarks-task-review`
+ - If no new results, checks if a run is in progress or needs to be triggered
+ - Compares results against previous runs
+ - Writes evaluation to the task's `review/` folder
+@@ -191,7 +191,7 @@ After all cycles or early stop:
+ ## What NOT to Do
+ 
+ - Don't spend multiple cycles on the same issue without trying a different approach
+-- Don't create new tasks without using `/gt-kaggle-benchmarks-task-generate`
++- Don't create new tasks without using `/geno-kaggle-benchmarks-task-generate`
+ - Don't modify notebooks without updating the timestamp
+ - Don't push broken code — verify changes make sense before committing
+ - Don't ignore CLAUDE.md rules (self-contained notebooks, llm as list, etc.)
+diff --git a/skills/geno-agents-tasks-start/SKILL.md b/skills/geno-agents-tasks-start/SKILL.md
+index c614003..f0ced30 100644
+--- a/skills/geno-agents-tasks-start/SKILL.md
++++ b/skills/geno-agents-tasks-start/SKILL.md
+@@ -4,7 +4,7 @@ description: >-
+   Pick up a task from the current workspace's geno-notes project scope,
+   plan if needed, and start executing. Workspace-only — global-scope tasks
+   are out of scope for v0.1.
+-  Installed by geno-tools as the /gt-tasks-start slash command.
++  Installed by geno-tools as the /geno-agents-tasks-start slash command.
+ license: MIT
+ metadata:
+   author: 42euge
+diff --git a/skills/geno-agents/SKILL.md b/skills/geno-agents/SKILL.md
+index 7a3ceaa..4964bb7 100644
+--- a/skills/geno-agents/SKILL.md
++++ b/skills/geno-agents/SKILL.md
+@@ -4,7 +4,7 @@ description: >-
+   Agent coordination — register as an agent, see who's online, update status.
+   Also includes autonomous agent loops (supercharge).
+   Use when user says /geno-agents, wants to register this session, check who's online,
+-  update what they're working on, or /gt-supercharge.
++  update what they're working on, or /geno-agents-supercharge.
+ allowed-tools: "Bash(geno-agents *) mcp__geno-agents__list_agents mcp__geno-agents__who mcp__geno-agents__whois mcp__geno-agents__update_agent mcp__geno-agents__register_agent"
+ argument-hint: "[who|whois|ls|register|update|status] [args...]"
+ license: MIT
+-- 
+2.43.0
+
+
+From cef4106ef0e1744b9298a8891fc14537237bac88 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 12 Jun 2026 00:13:42 +0000
+Subject: [PATCH 2/2] chore(geno-audit): untrack .geno-agents runtime file
+ (Section 1 FAIL)
+
+---
+ .geno-agents | 6 ------
+ .gitignore   | 1 +
+ 2 files changed, 1 insertion(+), 6 deletions(-)
+ delete mode 100644 .geno-agents
+
+diff --git a/.geno-agents b/.geno-agents
+deleted file mode 100644
+index 1b70527..0000000
+--- a/.geno-agents
++++ /dev/null
+@@ -1,6 +0,0 @@
+-role: geno-agents-dev
+-description: Agent coordination layer — registration, discovery, presence
+-capabilities:
+-  - coordination
+-  - registry
+-  - agent-framework
+diff --git a/.gitignore b/.gitignore
+index 9924060..fb47744 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -4,3 +4,4 @@ __pycache__/
+ dist/
+ build/
+ .env
++.geno-agents
+-- 
+2.43.0
+

--- a/.audit-patches-2026-06-12/geno-dev.patch
+++ b/.audit-patches-2026-06-12/geno-dev.patch
@@ -1,0 +1,187 @@
+From 3ac805f0a48520f42daf6d94b6bdafb24b8f68b1 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 12 Jun 2026 00:13:00 +0000
+Subject: [PATCH 1/2] chore(geno-audit): bring repo into ecosystem compliance
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+- Fix Section 11 (FAIL): Remove aliased /gt-pr command from
+  skills/geno-dev-prs-check/SKILL.md description — use canonical
+  /geno-dev-prs-check only
+- Fix Section 5 (WARN): Add geno-dev-sessions-remote to GENO.md skills
+  table and repo structure tree; add to README.md commands table and
+  repository structure tree
+- Fix Section 6 (WARN): Add versioning guidance to GENO.md Conventions
+  section (canonical version in genotools.yaml + package.json, bump
+  when skills are added/removed or behavior changes)
+- Fix Section 4 (WARN): Add allowed-tools field to root SKILL.md
+  frontmatter
+---
+ GENO.md                            | 3 +++
+ README.md                          | 3 +++
+ SKILL.md                           | 1 +
+ skills/geno-dev-prs-check/SKILL.md | 2 +-
+ 4 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/GENO.md b/GENO.md
+index 28d5e79..3e128f8 100644
+--- a/GENO.md
++++ b/GENO.md
+@@ -12,6 +12,7 @@ Developer and infrastructure skills for AI coding agents: task execution from la
+ | geno-dev-worktrees-manage | worktrees | /geno-dev-worktrees-manage |
+ | geno-dev-workspaces-init | workspaces | /geno-dev-workspaces-init |
+ | geno-dev-sessions-fork | sessions | /geno-dev-sessions-fork |
++| geno-dev-sessions-remote | sessions | /geno-dev-sessions-remote |
+ | geno-dev-prs-check | prs | /geno-dev-prs-check |
+ | geno-dev-branches-audit | branches | /geno-dev-branches-audit |
+ | geno-dev-scheduling-snooze | scheduling | /geno-dev-scheduling-snooze |
+@@ -32,6 +33,7 @@ geno-dev/
+ │   ├── geno-dev/        #   umbrella
+ │   ├── geno-dev-commits-rewrite/
+ │   ├── geno-dev-sessions-fork/
++│   ├── geno-dev-sessions-remote/
+ │   ├── geno-dev-tasks-start/
+ │   ├── geno-dev-workspaces-init/
+ │   ├── geno-dev-worktrees-manage/
+@@ -77,3 +79,4 @@ Pure markdown skillset — no Python package, no venv, no scripts. Each skill is
+ - This skill never modifies a project's `.gitignore` or tracked config files.
+ - **Prefix aliasing**: Slash commands use the canonical `geno-` prefix in source (e.g., `/geno-dev-tasks-start`). Short `/gt-` aliases are configured per-install by geno-tools and are not part of the skill source.
+ - **Adding a new skill**: Create a directory under `skills/` named after the skill, add a `SKILL.md` with valid frontmatter (name, description, argument-hint, license, metadata), then register the skill in the skills table and repo structure tree in this file.
++- **Versioning**: The canonical version lives in `genotools.yaml` (`version` field). The same value must appear in `package.json` (`version`). Bump the version whenever skills are added, removed, or behavior changes. Keep all version files in sync.
+diff --git a/README.md b/README.md
+index abd60ea..0b1d1b9 100644
+--- a/README.md
++++ b/README.md
+@@ -19,6 +19,7 @@ geno-tools install geno-dev
+ | `/geno-dev-worktrees-manage [list\|create\|switch\|prune]` | Manage git worktrees — list, create, switch, and prune |
+ | `/geno-dev-workspaces-init [config\|list\|<text>]` | Create development workspaces from issues, tickets, repos, or ideas |
+ | `/geno-dev-sessions-fork [session]` | Fork an agent session — extract context to continue in a new session |
++| `/geno-dev-sessions-remote [workspace-path]` | Start a remote-access agent session in a workspace directory |
+ | `/geno-dev-feature-ship [description\|issue URL]` | End-to-end: scope, issue, branch, implement, and PR |
+ | `/geno-dev-issue-work [number\|query\|URL]` | Pick a GitHub issue or JIRA ticket and work on it (normal or loop mode) |
+ | `/geno-dev-loops-drift [question]` | Question-driven exploration loop — maintains a prioritized question queue |
+@@ -48,6 +49,8 @@ geno-dev/
+ │   │   └── SKILL.md
+ │   ├── geno-dev-sessions-fork/
+ │   │   └── SKILL.md
++│   ├── geno-dev-sessions-remote/
++│   │   └── SKILL.md
+ │   ├── geno-dev-tasks-start/
+ │   │   └── SKILL.md
+ │   ├── geno-dev-workspaces-init/
+diff --git a/SKILL.md b/SKILL.md
+index 86e6752..4963b48 100644
+--- a/SKILL.md
++++ b/SKILL.md
+@@ -1,5 +1,6 @@
+ ---
+ name: geno-dev
++allowed-tools: "Bash(git *) Bash(gh *) Bash(geno-*) Read(*) Write(*) Edit(*) Glob(*) Grep(*)"
+ description: >-
+   Developer and infrastructure utilities — task execution from lab notes,
+   git commit history rewriting, worktree management, workspace creation,
+diff --git a/skills/geno-dev-prs-check/SKILL.md b/skills/geno-dev-prs-check/SKILL.md
+index 978fda0..c3e16d8 100644
+--- a/skills/geno-dev-prs-check/SKILL.md
++++ b/skills/geno-dev-prs-check/SKILL.md
+@@ -2,7 +2,7 @@
+ name: geno-dev-prs-check
+ description: >-
+   Check open PRs for repos in the current session and show which ones
+-  may need to be closed. Use when user says /geno-dev-prs-check or /gt-pr.
++  may need to be closed. Use when user says /geno-dev-prs-check.
+ argument-hint: "[repo|--all]"
+ license: MIT
+ metadata:
+-- 
+2.43.0
+
+
+From 3f491692fcdccf8a7c7590764f8c880f3e13a107 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 12 Jun 2026 00:15:21 +0000
+Subject: [PATCH 2/2] chore(geno-audit): remove stale loop skill refs from
+ SKILL.md; untrack .geno-agents
+
+---
+ .geno-agents |  9 ---------
+ .gitignore   |  1 +
+ SKILL.md     | 17 +++++------------
+ 3 files changed, 6 insertions(+), 21 deletions(-)
+ delete mode 100644 .geno-agents
+
+diff --git a/.geno-agents b/.geno-agents
+deleted file mode 100644
+index 69bb2fa..0000000
+--- a/.geno-agents
++++ /dev/null
+@@ -1,9 +0,0 @@
+-role: geno-dev
+-description: Developer utilities — task execution, commit rewriting, worktree management, workspace creation, agentic loops, scheduling
+-capabilities:
+-  - dev-tools
+-  - git-history
+-  - git-worktrees
+-  - workspaces
+-  - agentic-loops
+-  - scheduling
+diff --git a/.gitignore b/.gitignore
+index c1fb757..f16522d 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -9,3 +9,4 @@ build/
+ .env
+ .idea/
+ .vscode/
++.geno-agents
+diff --git a/SKILL.md b/SKILL.md
+index 4963b48..1a41bc3 100644
+--- a/SKILL.md
++++ b/SKILL.md
+@@ -5,14 +5,12 @@ description: >-
+   Developer and infrastructure utilities — task execution from lab notes,
+   git commit history rewriting, worktree management, workspace creation,
+   session forking, end-to-end feature shipping, issue-driven development,
+-  agentic loops, background monitoring, PR checking and branch auditing,
++  background monitoring, PR checking and branch auditing,
+   scheduled snoozing, and skill retrospectives.
+   Use when user says /geno-dev-tasks-start, /geno-dev-commits-rewrite,
+   /geno-dev-worktrees-manage, /geno-dev-workspaces-init, /geno-dev-sessions-fork,
+-  /geno-dev-feature-ship, /geno-dev-issue-work, /geno-dev-loops-drift,
+-  /geno-dev-loops-turbocharge, /geno-dev-loops-cruise,
+-  /geno-dev-loops-autopilot, /geno-dev-loops-boost,
+-  /geno-dev-loops-ignition, /geno-dev-prs-check, /geno-dev-branches-audit,
++  /geno-dev-sessions-remote, /geno-dev-feature-ship, /geno-dev-issue-work,
++  /geno-dev-prs-check, /geno-dev-branches-audit,
+   /geno-dev-scheduling-snooze, or /geno-dev-skills-retro.
+ license: MIT
+ metadata:
+@@ -22,7 +20,7 @@ metadata:
+ 
+ # geno-dev — Developer Utilities
+ 
+-Dev and infrastructure skills for AI coding agents. Task execution, git history rewriting, worktree management, workspace creation, session forking, end-to-end feature shipping, issue-driven development, agentic loops, background monitoring, PR checking and branch auditing, scheduled snoozing, and skill retrospectives.
++Dev and infrastructure skills for AI coding agents. Task execution, git history rewriting, worktree management, workspace creation, session forking, end-to-end feature shipping, issue-driven development, background monitoring, PR checking and branch auditing, scheduled snoozing, and skill retrospectives.
+ 
+ ## Commands
+ 
+@@ -33,14 +31,9 @@ Dev and infrastructure skills for AI coding agents. Task execution, git history
+ | `/geno-dev-worktrees-manage [list\|create\|switch\|prune]` | Manage git worktrees — list, create, switch, and prune |
+ | `/geno-dev-workspaces-init [config\|list\|<text>]` | Create development workspaces from issues, tickets, repos, or ideas |
+ | `/geno-dev-sessions-fork [session]` | Fork an agent session — extract context to continue in a new session |
++| `/geno-dev-sessions-remote [session]` | Start or continue a remote agent session |
+ | `/geno-dev-feature-ship [description\|issue URL]` | End-to-end: scope, issue, branch, implement, and PR |
+ | `/geno-dev-issue-work [number\|query\|URL]` | Pick a GitHub issue or JIRA ticket and work on it (normal or loop mode) |
+-| `/geno-dev-loops-drift [question]` | Question-driven exploration loop — maintains a prioritized question queue |
+-| `/geno-dev-loops-turbocharge [task] [--spec <file>]` | Spec-driven convergence loop — iterate until all acceptance criteria pass |
+-| `/geno-dev-loops-cruise [task] [--plan <file>]` | Plan-driven sequential loop — execute a plan one step at a time |
+-| `/geno-dev-loops-autopilot [task] [--watch <tests\|ci\|lint\|git\|all>]` | Background monitoring loop — watch CI, tests, lint, and git state |
+-| `/geno-dev-loops-boost [task]` | Pomodoro focus loop — time-boxed work blocks with reflection |
+-| `/geno-dev-loops-ignition [goal] [--blueprint <file>]` | Cold-start bootstrap loop — turn a high-level goal into a blueprint and verified first slice |
+ | `/geno-dev-prs-check [repo\|--all]` | Check open PRs and flag ones that may need closing |
+ | `/geno-dev-branches-audit [repo\|--all]` | Audit all branches — find ones needing PRs, ready to merge, or stale |
+ | `/geno-dev-scheduling-snooze <time> [prompt]` | Snooze session until a specified time, then execute a prompt |
+-- 
+2.43.0
+

--- a/.audit-patches-2026-06-12/geno-iso.patch
+++ b/.audit-patches-2026-06-12/geno-iso.patch
@@ -1,0 +1,402 @@
+From 81e8531ed2d52ac14f77ed1ea18a1e8a475be213 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 12 Jun 2026 00:11:34 +0000
+Subject: [PATCH] chore(geno-audit): bring repo into ecosystem compliance
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+- CLAUDE.md: replace full copy of GENO.md with pointer (@./GENO.md)
+- AGENTS.md: replace full copy of GENO.md with pointer (@import GENO.md)
+- GEMINI.md: replace full copy of GENO.md with pointer (@./GENO.md)
+- GENO.md: remove "Agent instruction files" section (ecosystem convention
+  restatement and wrong convention — files must be pointers, not copies)
+- GENO.md: fix Command prefix aliasing section — remove /gt- examples,
+  replace with canonical /geno- form per aliasing spec
+- GENO.md: add Versioning subsection under Conventions identifying the four
+  canonical version files and the bump rule
+- GENO.md: tighten Adding a new skill checklist — remove SKILL.md frontmatter
+  spec restatement, add versioning bump step referencing the Versioning section
+
+https://claude.ai/code/session_01VMsXYnkCiCgymeU4cc8wZy
+---
+ AGENTS.md | 106 +-----------------------------------------------------
+ CLAUDE.md | 106 +-----------------------------------------------------
+ GEMINI.md | 106 +-----------------------------------------------------
+ GENO.md   |  18 ++++------
+ 4 files changed, 9 insertions(+), 327 deletions(-)
+
+diff --git a/AGENTS.md b/AGENTS.md
+index 1ff2f96..21d33a9 100644
+--- a/AGENTS.md
++++ b/AGENTS.md
+@@ -1,105 +1 @@
+-# geno-iso -- isolated Docker containers for coding agents
+-
+-`geno-iso` is a Python CLI and skillset for running coding agents (Claude Code, Codex, Gemini CLI) inside Docker containers with OAuth credentials injected from the macOS Keychain.
+-
+-## Skills
+-
+-| Skill | Sub-skillset | Slash command |
+-|-------|-------------|---------------|
+-| geno-iso | -- | -- (umbrella) |
+-| geno-iso-containers-run | containers | /geno-iso-containers-run |
+-| geno-iso-containers-list | containers | /geno-iso-containers-list |
+-| geno-iso-containers-enter | containers | /geno-iso-containers-enter |
+-| geno-iso-images-build | images | /geno-iso-images-build |
+-| geno-iso-credentials-extract | credentials | /geno-iso-credentials-extract |
+-| geno-iso-dev-guide | -- | /geno-iso-dev-guide |
+-| geno-iso-housekeep | -- | /geno-iso-housekeep |
+-
+-## Repo structure
+-
+-```
+-geno-iso/
+-├── GENO.md              # agent instructions (this file)
+-├── SKILL.md             # umbrella skill manifest (-> skills/geno-iso/SKILL.md)
+-├── genotools.yaml       # geno-tools manifest
+-├── pyproject.toml       # Python CLI entry point
+-├── package.json         # skills manifest with name, version, skills map
+-├── .geno-agents         # agent identity: role, description, capabilities
+-├── dockerfiles/         # per-agent Dockerfiles
+-│   ├── base/            #   shared base image
+-│   ├── claude/          #   Claude Code container
+-│   ├── codex/           #   Codex container
+-│   └── gemini/          #   Gemini CLI container
+-├── geno_iso/            # Python CLI package
+-│   ├── cli.py           #   Click CLI (run, ls, it, stop, rm, build, creds, setup)
+-│   ├── docker.py        #   Docker lifecycle management
+-│   └── credentials.py   #   macOS Keychain extraction
+-├── skills/              # skill definitions
+-│   ├── geno-iso/                      # umbrella
+-│   ├── geno-iso-containers-run/       # spin up container
+-│   ├── geno-iso-containers-list/      # list containers
+-│   ├── geno-iso-containers-enter/     # interactive enter
+-│   ├── geno-iso-images-build/         # build Docker image
+-│   ├── geno-iso-credentials-extract/  # refresh credentials
+-│   ├── geno-iso-dev-guide/            # development guide
+-│   └── geno-iso-housekeep/            # background housekeeping daemon
+-└── docs/                # MkDocs Material site
+-```
+-
+-## Conventions
+-
+-### Command prefix aliasing
+-
+-Skills in this repo use the canonical `geno-` prefix in source (e.g., `geno-iso-containers-run`). When installed via `geno-tools`, the installer may configure shorter `/gt-` aliases (e.g., `/gt-iso-containers-run`) depending on the user's settings. Always author skill names and docs with the canonical `geno-` prefix; alias mapping is handled at install time and never committed to this repo.
+-
+-### Agent instruction files
+-
+-`AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` are **full copies** of `GENO.md` — not pointers (`@./GENO.md`). After every edit to `GENO.md`, run:
+-
+-```bash
+-cp GENO.md AGENTS.md && cp GENO.md CLAUDE.md && cp GENO.md GEMINI.md
+-```
+-
+-Rationale: pointer files are fragile across agent runtimes and editor integrations. Full copies ensure every agent sees the same instructions regardless of runtime.
+-
+-### Adding a new skill
+-
+-1. Create a directory under `skills/` named after the skill (e.g., `skills/geno-iso-<verb>-<noun>/`).
+-2. Add a `SKILL.md` with YAML front matter (`name`, `description`, `allowed-tools`, `argument-hint`, `license`, `metadata`).
+-3. Register the skill in `package.json` under the `skills` map.
+-4. Register the skill in `skills.sh.json` under the appropriate grouping.
+-5. Add a row to the Skills table in this file.
+-6. If the skill belongs to a sub-skillset, note it in the table's Sub-skillset column.
+-7. Copy GENO.md → AGENTS.md, CLAUDE.md, GEMINI.md.
+-
+-## CLI
+-
+-Entry point: `geno-iso = "geno_iso.cli:main"`
+-
+-| Command | Description |
+-|---|---|
+-| `geno-iso run [NAME] [WORKSPACE]` | Create/restart a persistent background container |
+-| `geno-iso run --rm [NAME] [WORKSPACE] -- [ARGS]` | One-shot: run agent and remove on exit |
+-| `geno-iso ls [--all] [--json]` | List geno-iso containers |
+-| `geno-iso it [NAME] [--shell]` | Exec into a running container (agent CLI or bash) |
+-| `geno-iso stop [NAME]` | Stop a container |
+-| `geno-iso rm [NAME] [-f]` | Remove a container |
+-| `geno-iso build [--agent] [--version]` | Build Docker image(s) |
+-| `geno-iso creds` | Extract OAuth credentials from Keychain |
+-| `geno-iso setup` | Sync Dockerfiles to ~/.geno/geno-iso/dockerfiles/ |
+-
+-## Architecture
+-
+-Persistent containers run `tail -f /dev/null` to stay alive. Users interact via `geno-iso it` which calls `docker exec -it`. One-shot mode (`--rm`) runs the agent directly and removes the container on exit.
+-
+-The `--agent` flag selects which coding agent to run (`claude`, `codex`, or `gemini`). Each agent has its own Dockerfile under `dockerfiles/` built on a shared base image.
+-
+-## How auth works
+-
+-OAuth credentials are extracted from the macOS Keychain (`Claude Code-credentials`) and injected as environment variables (`CLAUDE_CODE_OAUTH_TOKEN`, `CLAUDE_CODE_OAUTH_REFRESH_TOKEN`, `CLAUDE_CODE_OAUTH_SCOPES`). Access tokens expire periodically -- run `geno-iso creds` to refresh, or the CLI auto-refreshes if the `.env` is older than 4 hours.
+-
+-## Dependencies and runtime
+-
+-- **Python >= 3.10** with `click >= 8.0`
+-- **Docker** must be installed and running
+-- **macOS Keychain** for credential extraction (Linux users create `.env` manually)
++@import GENO.md
+diff --git a/CLAUDE.md b/CLAUDE.md
+index 1ff2f96..a132988 100644
+--- a/CLAUDE.md
++++ b/CLAUDE.md
+@@ -1,105 +1 @@
+-# geno-iso -- isolated Docker containers for coding agents
+-
+-`geno-iso` is a Python CLI and skillset for running coding agents (Claude Code, Codex, Gemini CLI) inside Docker containers with OAuth credentials injected from the macOS Keychain.
+-
+-## Skills
+-
+-| Skill | Sub-skillset | Slash command |
+-|-------|-------------|---------------|
+-| geno-iso | -- | -- (umbrella) |
+-| geno-iso-containers-run | containers | /geno-iso-containers-run |
+-| geno-iso-containers-list | containers | /geno-iso-containers-list |
+-| geno-iso-containers-enter | containers | /geno-iso-containers-enter |
+-| geno-iso-images-build | images | /geno-iso-images-build |
+-| geno-iso-credentials-extract | credentials | /geno-iso-credentials-extract |
+-| geno-iso-dev-guide | -- | /geno-iso-dev-guide |
+-| geno-iso-housekeep | -- | /geno-iso-housekeep |
+-
+-## Repo structure
+-
+-```
+-geno-iso/
+-├── GENO.md              # agent instructions (this file)
+-├── SKILL.md             # umbrella skill manifest (-> skills/geno-iso/SKILL.md)
+-├── genotools.yaml       # geno-tools manifest
+-├── pyproject.toml       # Python CLI entry point
+-├── package.json         # skills manifest with name, version, skills map
+-├── .geno-agents         # agent identity: role, description, capabilities
+-├── dockerfiles/         # per-agent Dockerfiles
+-│   ├── base/            #   shared base image
+-│   ├── claude/          #   Claude Code container
+-│   ├── codex/           #   Codex container
+-│   └── gemini/          #   Gemini CLI container
+-├── geno_iso/            # Python CLI package
+-│   ├── cli.py           #   Click CLI (run, ls, it, stop, rm, build, creds, setup)
+-│   ├── docker.py        #   Docker lifecycle management
+-│   └── credentials.py   #   macOS Keychain extraction
+-├── skills/              # skill definitions
+-│   ├── geno-iso/                      # umbrella
+-│   ├── geno-iso-containers-run/       # spin up container
+-│   ├── geno-iso-containers-list/      # list containers
+-│   ├── geno-iso-containers-enter/     # interactive enter
+-│   ├── geno-iso-images-build/         # build Docker image
+-│   ├── geno-iso-credentials-extract/  # refresh credentials
+-│   ├── geno-iso-dev-guide/            # development guide
+-│   └── geno-iso-housekeep/            # background housekeeping daemon
+-└── docs/                # MkDocs Material site
+-```
+-
+-## Conventions
+-
+-### Command prefix aliasing
+-
+-Skills in this repo use the canonical `geno-` prefix in source (e.g., `geno-iso-containers-run`). When installed via `geno-tools`, the installer may configure shorter `/gt-` aliases (e.g., `/gt-iso-containers-run`) depending on the user's settings. Always author skill names and docs with the canonical `geno-` prefix; alias mapping is handled at install time and never committed to this repo.
+-
+-### Agent instruction files
+-
+-`AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` are **full copies** of `GENO.md` — not pointers (`@./GENO.md`). After every edit to `GENO.md`, run:
+-
+-```bash
+-cp GENO.md AGENTS.md && cp GENO.md CLAUDE.md && cp GENO.md GEMINI.md
+-```
+-
+-Rationale: pointer files are fragile across agent runtimes and editor integrations. Full copies ensure every agent sees the same instructions regardless of runtime.
+-
+-### Adding a new skill
+-
+-1. Create a directory under `skills/` named after the skill (e.g., `skills/geno-iso-<verb>-<noun>/`).
+-2. Add a `SKILL.md` with YAML front matter (`name`, `description`, `allowed-tools`, `argument-hint`, `license`, `metadata`).
+-3. Register the skill in `package.json` under the `skills` map.
+-4. Register the skill in `skills.sh.json` under the appropriate grouping.
+-5. Add a row to the Skills table in this file.
+-6. If the skill belongs to a sub-skillset, note it in the table's Sub-skillset column.
+-7. Copy GENO.md → AGENTS.md, CLAUDE.md, GEMINI.md.
+-
+-## CLI
+-
+-Entry point: `geno-iso = "geno_iso.cli:main"`
+-
+-| Command | Description |
+-|---|---|
+-| `geno-iso run [NAME] [WORKSPACE]` | Create/restart a persistent background container |
+-| `geno-iso run --rm [NAME] [WORKSPACE] -- [ARGS]` | One-shot: run agent and remove on exit |
+-| `geno-iso ls [--all] [--json]` | List geno-iso containers |
+-| `geno-iso it [NAME] [--shell]` | Exec into a running container (agent CLI or bash) |
+-| `geno-iso stop [NAME]` | Stop a container |
+-| `geno-iso rm [NAME] [-f]` | Remove a container |
+-| `geno-iso build [--agent] [--version]` | Build Docker image(s) |
+-| `geno-iso creds` | Extract OAuth credentials from Keychain |
+-| `geno-iso setup` | Sync Dockerfiles to ~/.geno/geno-iso/dockerfiles/ |
+-
+-## Architecture
+-
+-Persistent containers run `tail -f /dev/null` to stay alive. Users interact via `geno-iso it` which calls `docker exec -it`. One-shot mode (`--rm`) runs the agent directly and removes the container on exit.
+-
+-The `--agent` flag selects which coding agent to run (`claude`, `codex`, or `gemini`). Each agent has its own Dockerfile under `dockerfiles/` built on a shared base image.
+-
+-## How auth works
+-
+-OAuth credentials are extracted from the macOS Keychain (`Claude Code-credentials`) and injected as environment variables (`CLAUDE_CODE_OAUTH_TOKEN`, `CLAUDE_CODE_OAUTH_REFRESH_TOKEN`, `CLAUDE_CODE_OAUTH_SCOPES`). Access tokens expire periodically -- run `geno-iso creds` to refresh, or the CLI auto-refreshes if the `.env` is older than 4 hours.
+-
+-## Dependencies and runtime
+-
+-- **Python >= 3.10** with `click >= 8.0`
+-- **Docker** must be installed and running
+-- **macOS Keychain** for credential extraction (Linux users create `.env` manually)
++@./GENO.md
+diff --git a/GEMINI.md b/GEMINI.md
+index 1ff2f96..a132988 100644
+--- a/GEMINI.md
++++ b/GEMINI.md
+@@ -1,105 +1 @@
+-# geno-iso -- isolated Docker containers for coding agents
+-
+-`geno-iso` is a Python CLI and skillset for running coding agents (Claude Code, Codex, Gemini CLI) inside Docker containers with OAuth credentials injected from the macOS Keychain.
+-
+-## Skills
+-
+-| Skill | Sub-skillset | Slash command |
+-|-------|-------------|---------------|
+-| geno-iso | -- | -- (umbrella) |
+-| geno-iso-containers-run | containers | /geno-iso-containers-run |
+-| geno-iso-containers-list | containers | /geno-iso-containers-list |
+-| geno-iso-containers-enter | containers | /geno-iso-containers-enter |
+-| geno-iso-images-build | images | /geno-iso-images-build |
+-| geno-iso-credentials-extract | credentials | /geno-iso-credentials-extract |
+-| geno-iso-dev-guide | -- | /geno-iso-dev-guide |
+-| geno-iso-housekeep | -- | /geno-iso-housekeep |
+-
+-## Repo structure
+-
+-```
+-geno-iso/
+-├── GENO.md              # agent instructions (this file)
+-├── SKILL.md             # umbrella skill manifest (-> skills/geno-iso/SKILL.md)
+-├── genotools.yaml       # geno-tools manifest
+-├── pyproject.toml       # Python CLI entry point
+-├── package.json         # skills manifest with name, version, skills map
+-├── .geno-agents         # agent identity: role, description, capabilities
+-├── dockerfiles/         # per-agent Dockerfiles
+-│   ├── base/            #   shared base image
+-│   ├── claude/          #   Claude Code container
+-│   ├── codex/           #   Codex container
+-│   └── gemini/          #   Gemini CLI container
+-├── geno_iso/            # Python CLI package
+-│   ├── cli.py           #   Click CLI (run, ls, it, stop, rm, build, creds, setup)
+-│   ├── docker.py        #   Docker lifecycle management
+-│   └── credentials.py   #   macOS Keychain extraction
+-├── skills/              # skill definitions
+-│   ├── geno-iso/                      # umbrella
+-│   ├── geno-iso-containers-run/       # spin up container
+-│   ├── geno-iso-containers-list/      # list containers
+-│   ├── geno-iso-containers-enter/     # interactive enter
+-│   ├── geno-iso-images-build/         # build Docker image
+-│   ├── geno-iso-credentials-extract/  # refresh credentials
+-│   ├── geno-iso-dev-guide/            # development guide
+-│   └── geno-iso-housekeep/            # background housekeeping daemon
+-└── docs/                # MkDocs Material site
+-```
+-
+-## Conventions
+-
+-### Command prefix aliasing
+-
+-Skills in this repo use the canonical `geno-` prefix in source (e.g., `geno-iso-containers-run`). When installed via `geno-tools`, the installer may configure shorter `/gt-` aliases (e.g., `/gt-iso-containers-run`) depending on the user's settings. Always author skill names and docs with the canonical `geno-` prefix; alias mapping is handled at install time and never committed to this repo.
+-
+-### Agent instruction files
+-
+-`AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` are **full copies** of `GENO.md` — not pointers (`@./GENO.md`). After every edit to `GENO.md`, run:
+-
+-```bash
+-cp GENO.md AGENTS.md && cp GENO.md CLAUDE.md && cp GENO.md GEMINI.md
+-```
+-
+-Rationale: pointer files are fragile across agent runtimes and editor integrations. Full copies ensure every agent sees the same instructions regardless of runtime.
+-
+-### Adding a new skill
+-
+-1. Create a directory under `skills/` named after the skill (e.g., `skills/geno-iso-<verb>-<noun>/`).
+-2. Add a `SKILL.md` with YAML front matter (`name`, `description`, `allowed-tools`, `argument-hint`, `license`, `metadata`).
+-3. Register the skill in `package.json` under the `skills` map.
+-4. Register the skill in `skills.sh.json` under the appropriate grouping.
+-5. Add a row to the Skills table in this file.
+-6. If the skill belongs to a sub-skillset, note it in the table's Sub-skillset column.
+-7. Copy GENO.md → AGENTS.md, CLAUDE.md, GEMINI.md.
+-
+-## CLI
+-
+-Entry point: `geno-iso = "geno_iso.cli:main"`
+-
+-| Command | Description |
+-|---|---|
+-| `geno-iso run [NAME] [WORKSPACE]` | Create/restart a persistent background container |
+-| `geno-iso run --rm [NAME] [WORKSPACE] -- [ARGS]` | One-shot: run agent and remove on exit |
+-| `geno-iso ls [--all] [--json]` | List geno-iso containers |
+-| `geno-iso it [NAME] [--shell]` | Exec into a running container (agent CLI or bash) |
+-| `geno-iso stop [NAME]` | Stop a container |
+-| `geno-iso rm [NAME] [-f]` | Remove a container |
+-| `geno-iso build [--agent] [--version]` | Build Docker image(s) |
+-| `geno-iso creds` | Extract OAuth credentials from Keychain |
+-| `geno-iso setup` | Sync Dockerfiles to ~/.geno/geno-iso/dockerfiles/ |
+-
+-## Architecture
+-
+-Persistent containers run `tail -f /dev/null` to stay alive. Users interact via `geno-iso it` which calls `docker exec -it`. One-shot mode (`--rm`) runs the agent directly and removes the container on exit.
+-
+-The `--agent` flag selects which coding agent to run (`claude`, `codex`, or `gemini`). Each agent has its own Dockerfile under `dockerfiles/` built on a shared base image.
+-
+-## How auth works
+-
+-OAuth credentials are extracted from the macOS Keychain (`Claude Code-credentials`) and injected as environment variables (`CLAUDE_CODE_OAUTH_TOKEN`, `CLAUDE_CODE_OAUTH_REFRESH_TOKEN`, `CLAUDE_CODE_OAUTH_SCOPES`). Access tokens expire periodically -- run `geno-iso creds` to refresh, or the CLI auto-refreshes if the `.env` is older than 4 hours.
+-
+-## Dependencies and runtime
+-
+-- **Python >= 3.10** with `click >= 8.0`
+-- **Docker** must be installed and running
+-- **macOS Keychain** for credential extraction (Linux users create `.env` manually)
++@./GENO.md
+diff --git a/GENO.md b/GENO.md
+index 1ff2f96..0f50da1 100644
+--- a/GENO.md
++++ b/GENO.md
+@@ -50,27 +50,21 @@ geno-iso/
+ 
+ ### Command prefix aliasing
+ 
+-Skills in this repo use the canonical `geno-` prefix in source (e.g., `geno-iso-containers-run`). When installed via `geno-tools`, the installer may configure shorter `/gt-` aliases (e.g., `/gt-iso-containers-run`) depending on the user's settings. Always author skill names and docs with the canonical `geno-` prefix; alias mapping is handled at install time and never committed to this repo.
++Skills in this repo use the canonical `geno-` prefix in source (e.g., `/geno-iso-containers-run`). The prefix users type at runtime is configured per-installation in `~/.geno/config.yaml` and applied at install time by `geno-tools install`. Never hardcode an aliased prefix like `gt-` in SKILL.md descriptions, GENO.md, or any committed file.
+ 
+-### Agent instruction files
++### Versioning
+ 
+-`AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` are **full copies** of `GENO.md` — not pointers (`@./GENO.md`). After every edit to `GENO.md`, run:
+-
+-```bash
+-cp GENO.md AGENTS.md && cp GENO.md CLAUDE.md && cp GENO.md GEMINI.md
+-```
+-
+-Rationale: pointer files are fragile across agent runtimes and editor integrations. Full copies ensure every agent sees the same instructions regardless of runtime.
++The canonical version lives in `genotools.yaml`. The same value must appear in `pyproject.toml` (`project.version`), `package.json` (`version`), and `geno_iso/__init__.py` (`__version__`). Bump the version whenever skills are added, removed, or behavior changes.
+ 
+ ### Adding a new skill
+ 
+-1. Create a directory under `skills/` named after the skill (e.g., `skills/geno-iso-<verb>-<noun>/`).
+-2. Add a `SKILL.md` with YAML front matter (`name`, `description`, `allowed-tools`, `argument-hint`, `license`, `metadata`).
++1. Create a directory under `skills/` named after the skill (e.g., `skills/geno-iso-<sub-skillset>-<verb>/`).
++2. Add a `SKILL.md` with YAML frontmatter (`name`, `description`, `allowed-tools`).
+ 3. Register the skill in `package.json` under the `skills` map.
+ 4. Register the skill in `skills.sh.json` under the appropriate grouping.
+ 5. Add a row to the Skills table in this file.
+ 6. If the skill belongs to a sub-skillset, note it in the table's Sub-skillset column.
+-7. Copy GENO.md → AGENTS.md, CLAUDE.md, GEMINI.md.
++7. Bump the version in all four files (see Versioning above).
+ 
+ ## CLI
+ 
+-- 
+2.43.0
+

--- a/.audit-patches-2026-06-12/geno-mine.patch
+++ b/.audit-patches-2026-06-12/geno-mine.patch
@@ -1,0 +1,276 @@
+From d5ecb5e32650b328031f80a742f40ac4811216d0 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 12 Jun 2026 00:11:22 +0000
+Subject: [PATCH] chore(geno-audit): bring repo into ecosystem compliance
+
+- Add AGENTS.md (pointer to GENO.md for Codex/Antigravity CLI)
+- Add GEMINI.md (pointer to GENO.md for Gemini agent)
+- Add LICENSE (MIT 2025, author 42euge)
+- Expand GENO.md with required Conventions section: command prefix
+  aliasing, adding-a-new-skill checklist, versioning guidance; add
+  geno-mine-backfill to skills table; fix agent-agnostic framing
+- Fix agent-agnostic language in docs/getting-started.md: replace
+  "Claude Code" exclusive framing with "a supported coding CLI /
+  from within an agent session"
+- Fix agent-agnostic language in skills/geno-mine/SKILL.md: replace
+  "Claude Code session transcripts" with "agent session transcripts"
+- Add skills/geno-mine-backfill/SKILL.md for the backfill CLI
+  subcommand that previously had no corresponding skill definition;
+  update umbrella skill to list it
+---
+ AGENTS.md                          |  1 +
+ GEMINI.md                          |  1 +
+ GENO.md                            | 47 ++++++++++++++++++-----
+ LICENSE                            | 21 +++++++++++
+ docs/getting-started.md            |  9 ++++-
+ skills/geno-mine-backfill/SKILL.md | 60 ++++++++++++++++++++++++++++++
+ skills/geno-mine/SKILL.md          |  5 ++-
+ 7 files changed, 132 insertions(+), 12 deletions(-)
+ create mode 100644 AGENTS.md
+ create mode 100644 GEMINI.md
+ create mode 100644 LICENSE
+ create mode 100644 skills/geno-mine-backfill/SKILL.md
+
+diff --git a/AGENTS.md b/AGENTS.md
+new file mode 100644
+index 0000000..21d33a9
+--- /dev/null
++++ b/AGENTS.md
+@@ -0,0 +1 @@
++@import GENO.md
+diff --git a/GEMINI.md b/GEMINI.md
+new file mode 100644
+index 0000000..a132988
+--- /dev/null
++++ b/GEMINI.md
+@@ -0,0 +1 @@
++@./GENO.md
+diff --git a/GENO.md b/GENO.md
+index 1dc24af..25a042c 100644
+--- a/GENO.md
++++ b/GENO.md
+@@ -1,15 +1,16 @@
+ # geno-mine — Session Mining and Finetuning Dataset Generation
+ 
+-`geno-mine` extracts finetuning datasets from Claude Code session transcripts. It correlates structured skill traces (from `geno-trace`) with raw JSONL transcripts, classifies segments by training value, applies privacy filters, and generates examples in multiple formats.
++`geno-mine` extracts finetuning datasets from agent session transcripts. It correlates structured skill traces (from `geno-trace`) with raw JSONL transcripts, classifies segments by training value, applies privacy filters, and generates examples in multiple formats.
+ 
+ ## Skills
+ 
+-| Skill | Slash command | Purpose |
+-|-------|---------------|---------|
+-| geno-mine | — | Umbrella |
+-| geno-mine-extract | /geno-mine-extract | Run the full mining pipeline |
+-| geno-mine-stats | /geno-mine-stats | Show dataset statistics |
+-| geno-mine-export | /geno-mine-export | Export datasets |
++| Skill | Sub-skillset | Slash command |
++|-------|-------------|---------------|
++| geno-mine | — | — (umbrella) |
++| geno-mine-extract | — | /geno-mine-extract |
++| geno-mine-stats | — | /geno-mine-stats |
++| geno-mine-export | — | /geno-mine-export |
++| geno-mine-backfill | — | /geno-mine-backfill |
+ 
+ ## Repo structure
+ 
+@@ -20,17 +21,19 @@ geno-mine/
+ ├── genotools.yaml                       # install manifest
+ ├── pyproject.toml                       # Python package metadata
+ ├── geno_mine/                           # Python package
+-│   ├── cli.py                           #   CLI entry points (extract/stats/export)
++│   ├── cli.py                           #   CLI entry points (extract/stats/export/backfill)
+ │   ├── correlator.py                    #   link traces to transcript segments
+ │   ├── signals.py                       #   classify segment value (tier 1/2/3)
+ │   ├── generator.py                     #   produce SFT, DPO, tool-trace examples
+ │   ├── filters.py                       #   privacy: path scrub, secret/PII removal
++│   ├── backfill.py                      #   retroactively generate traces from transcripts
+ │   └── store.py                         #   dataset versioning at ~/.geno/datasets/
+ └── skills/
+     ├── geno-mine/SKILL.md               #   umbrella
+     ├── geno-mine-extract/SKILL.md       #   full pipeline skill
+     ├── geno-mine-stats/SKILL.md         #   statistics skill
+-    └── geno-mine-export/SKILL.md        #   export skill
++    ├── geno-mine-export/SKILL.md        #   export skill
++    └── geno-mine-backfill/SKILL.md      #   backfill skill
+ ```
+ 
+ ## Entry point
+@@ -58,3 +61,29 @@ All processing is local (zero telemetry). The filter stage:
+ 3. Replaces emails and phone numbers with placeholders
+ 4. Skips segments that touch `.env`, credentials, `~/.ssh/`
+ 5. Configurable exclusions in `~/.geno/config.yaml` under `mining`
++
++## Conventions
++
++### Command prefix aliasing
++
++Slash commands in this repo always use the canonical `geno-` prefix (e.g., `/geno-mine-extract`, `/geno-mine-stats`). The prefix users actually type at runtime (`/gt-`, `/geno-`, or bare `/`) is a user preference configured in `~/.geno/config.yaml`:
++
++```yaml
++aliases:
++  command_prefix: "gt"   # gt-mine-extract, gt-mine-stats, etc.
++```
++
++The prefix is applied at install time by `geno-tools install`. Never hardcode an aliased prefix like `gt-` in SKILL.md descriptions, GENO.md, or any committed file.
++
++### Adding a new skill
++
++1. Create a directory under `skills/` named with the full skill name (e.g., `skills/geno-mine-backfill/`).
++2. Write a `SKILL.md` inside it with YAML frontmatter containing at minimum `name` and `description`.
++3. Update the umbrella skill description in `skills/geno-mine/SKILL.md` to list the new skill.
++4. Add the skill to the skills table in this file (`GENO.md`).
++5. If the skill has a corresponding CLI subcommand, add or verify it in `geno_mine/cli.py`.
++6. Bump the version in all four files: `genotools.yaml`, `pyproject.toml`, `package.json` (if present), `geno_mine/__init__.py`.
++
++### Versioning
++
++The canonical version lives in `genotools.yaml` (`version` field). The same value must appear in `pyproject.toml` (`project.version`) and `geno_mine/__init__.py` (`__version__`). Bump the version whenever skills are added, removed, or behavior changes. Keep all files in sync.
+diff --git a/LICENSE b/LICENSE
+new file mode 100644
+index 0000000..6026324
+--- /dev/null
++++ b/LICENSE
+@@ -0,0 +1,21 @@
++MIT License
++
++Copyright (c) 2025 42euge
++
++Permission is hereby granted, free of charge, to any person obtaining a copy
++of this software and associated documentation files (the "Software"), to deal
++in the Software without restriction, including without limitation the rights
++to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
++copies of the Software, and to permit persons to whom the Software is
++furnished to do so, subject to the following conditions:
++
++The above copyright notice and this permission notice shall be included in all
++copies or substantial portions of the Software.
++
++THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++SOFTWARE.
+diff --git a/docs/getting-started.md b/docs/getting-started.md
+index dce645e..40e2ba3 100644
+--- a/docs/getting-started.md
++++ b/docs/getting-started.md
+@@ -2,6 +2,7 @@
+ 
+ ## Prerequisites
+ 
++- A supported coding CLI (Claude Code, Antigravity CLI, Codex, or OpenCode)
+ - [geno-tools](https://github.com/42euge/geno-tools) installed
+ 
+ ## Installation
+@@ -10,6 +11,12 @@
+ geno-tools install geno-mine
+ ```
+ 
++Or from within an agent session:
++
++```
++/geno-tools install geno-mine
++```
++
+ ## Usage
+ 
+-Run `/geno-mine` in Claude Code to get started.
++Run `/geno-mine` from within an agent session to get started.
+diff --git a/skills/geno-mine-backfill/SKILL.md b/skills/geno-mine-backfill/SKILL.md
+new file mode 100644
+index 0000000..da4af1f
+--- /dev/null
++++ b/skills/geno-mine-backfill/SKILL.md
+@@ -0,0 +1,60 @@
++---
++name: geno-mine-backfill
++description: >-
++  Retroactively generate skill traces from historical agent session transcripts.
++  Use when user says /geno-mine-backfill.
++argument-hint: "[--since <days>d] [--skill <name>] [--dry-run]"
++license: MIT
++metadata:
++  author: 42euge
++  version: "0.1.0"
++observability:
++  success_signal: "traces emitted > 0"
++  failure_signals:
++    - "no transcripts found"
++    - "no invocations detected"
++  knowledge_reads:
++    - "~/.claude/projects/ (historical session transcripts)"
++  knowledge_writes:
++    - "~/.geno/traces/ (retroactively generated skill traces)"
++---
++
++# Backfill Traces
++
++Retroactively generate skill traces from historical session transcripts. Useful
++when transcripts exist but traces were not emitted at the time (e.g., before
++`geno-trace` was set up). Deduplicates against existing traces to avoid
++double-counting.
++
++## Workflow
++
++### 1. Run the backfill
++
++```bash
++geno-mine backfill [--since 30d] [--skill <name>] [--dry-run]
++```
++
++Parse `$ARGUMENTS` and pass them to the CLI.
++
++### 2. Review results
++
++Show the user what was generated:
++- Transcripts scanned
++- Invocations found
++- Traces emitted
++- Traces skipped (deduplication)
++- Breakdown by skill and outcome
++
++### 3. Suggest next steps
++
++- `geno-mine extract` to mine the newly backfilled traces into training examples
++
++## Completion
++
++```bash
++geno-trace emit \
++  --skill geno-mine-backfill \
++  --status <success|failure> \
++  --tool-calls <count> \
++  --errors <count>
++```
+diff --git a/skills/geno-mine/SKILL.md b/skills/geno-mine/SKILL.md
+index c0ffbae..58e3751 100644
+--- a/skills/geno-mine/SKILL.md
++++ b/skills/geno-mine/SKILL.md
+@@ -2,7 +2,7 @@
+ name: geno-mine
+ description: >-
+   Session mining and finetuning dataset generation — extract training examples
+-  from Claude Code session transcripts. Use when user says /geno-mine.
++  from agent session transcripts. Use when user says /geno-mine.
+ license: MIT
+ metadata:
+   author: 42euge
+@@ -12,7 +12,7 @@ metadata:
+ # geno-mine
+ 
+ Session mining toolkit for the geno ecosystem. Extracts finetuning datasets
+-from Claude Code session transcripts by correlating structured skill traces
++from agent session transcripts by correlating structured skill traces
+ with raw JSONL transcripts, classifying segments by training value, and
+ generating examples in multiple formats (SFT, DPO, tool traces, Anthropic).
+ 
+@@ -23,3 +23,4 @@ generating examples in multiple formats (SFT, DPO, tool traces, Anthropic).
+ | geno-mine-extract | /geno-mine-extract | Run the full mining pipeline |
+ | geno-mine-stats | /geno-mine-stats | Show dataset statistics |
+ | geno-mine-export | /geno-mine-export | Export datasets to external formats |
++| geno-mine-backfill | /geno-mine-backfill | Retroactively generate traces from historical transcripts |
+-- 
+2.43.0
+

--- a/.audit-patches-2026-06-12/geno-notes.patch
+++ b/.audit-patches-2026-06-12/geno-notes.patch
@@ -1,0 +1,450 @@
+From ae9b86d2949a867d0bb626ef54959d7063afe747 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 12 Jun 2026 00:13:57 +0000
+Subject: [PATCH] chore(geno-audit): bring repo into ecosystem compliance
+
+Section 3 (Versioning): sync __version__ in geno_notes/__init__.py from
+0.2.0 to 0.1.0 to match genotools.yaml, pyproject.toml, and package.json.
+
+Section 5 (Skill Nomenclature): add four missing sub-skillset skill
+directories to cover the 20 CLI subcommands that had no corresponding
+skills/geno-notes-{sub-skillset}/SKILL.md:
+  - skills/geno-notes-tasks/     (add, start, done, abandon, list, show)
+  - skills/geno-notes-inbox/     (inbox, triage, promote)
+  - skills/geno-notes-search/    (search, reindex)
+  - skills/geno-notes-workspace/ (scope, path, context)
+
+Section 6 (Agent Instruction Files): add versioning guidance to GENO.md
+Conventions section naming all four files that must stay in sync.
+
+Also: update SKILL.md (root and skills/geno-notes/), GENO.md skills table,
+GENO.md repo structure, README.md repo structure, and package.json skills
+map to register and document the new sub-skills.
+---
+ GENO.md                              | 15 +++++-
+ README.md                            | 20 ++++++--
+ SKILL.md                             |  6 +++
+ geno_notes/__init__.py               |  2 +-
+ package.json                         |  4 ++
+ skills/geno-notes-inbox/SKILL.md     | 56 +++++++++++++++++++++
+ skills/geno-notes-search/SKILL.md    | 52 +++++++++++++++++++
+ skills/geno-notes-tasks/SKILL.md     | 74 ++++++++++++++++++++++++++++
+ skills/geno-notes-workspace/SKILL.md | 59 ++++++++++++++++++++++
+ skills/geno-notes/SKILL.md           |  5 ++
+ 10 files changed, 287 insertions(+), 6 deletions(-)
+ create mode 100644 skills/geno-notes-inbox/SKILL.md
+ create mode 100644 skills/geno-notes-search/SKILL.md
+ create mode 100644 skills/geno-notes-tasks/SKILL.md
+ create mode 100644 skills/geno-notes-workspace/SKILL.md
+
+diff --git a/GENO.md b/GENO.md
+index ac91d45..9dec164 100644
+--- a/GENO.md
++++ b/GENO.md
+@@ -7,6 +7,10 @@ Project journal for AI coding agents: tasks, timestamped journal entries, plans.
+ | Skill | Sub-skillset | Slash command |
+ |-------|-------------|---------------|
+ | geno-notes | — | — (umbrella) |
++| geno-notes-tasks | tasks | /geno-notes-tasks |
++| geno-notes-inbox | inbox | /geno-notes-inbox |
++| geno-notes-search | search | /geno-notes-search |
++| geno-notes-workspace | workspace | /geno-notes-workspace |
+ | geno-notes-init | init | /geno-notes-init |
+ | geno-notes-wiki-compile | wiki | /geno-notes-wiki-compile |
+ | geno-notes-wiki-lint | wiki | /geno-notes-wiki-lint |
+@@ -21,7 +25,15 @@ geno-notes/
+ ├── SKILL.md             # umbrella skill manifest
+ ├── genotools.yaml       # geno-tools manifest
+ ├── skills/
+-│   ├── geno-notes/                #   umbrella skill
++│   ├── geno-notes/                 #   umbrella skill
++│   │   └── SKILL.md
++│   ├── geno-notes-tasks/           #   sub-skill: task lifecycle (add, start, done, abandon, list, show)
++│   │   └── SKILL.md
++│   ├── geno-notes-inbox/           #   sub-skill: inbox management (capture, triage, promote)
++│   │   └── SKILL.md
++│   ├── geno-notes-search/          #   sub-skill: search and reindex
++│   │   └── SKILL.md
++│   ├── geno-notes-workspace/       #   sub-skill: scope inspection and context bundles
+ │   │   └── SKILL.md
+ │   ├── geno-notes-init/            #   sub-skill: initialize wiki
+ │   │   └── SKILL.md
+@@ -56,6 +68,7 @@ geno-notes/
+ - The umbrella slash command `/geno-notes` dispatches to the `geno-notes` CLI binary.
+ - **Prefix aliasing**: slash commands use the canonical `geno-` prefix in source (e.g., `/geno-notes`). Short `/gt-` aliases (e.g., `/gt-notes`) are configured per-installation by `geno-tools` and are not defined in this repo.
+ - **Adding a new skill**: create a directory under `skills/` named after the skill, write a `SKILL.md` with YAML frontmatter (name, description, allowed-tools, etc.), add the skill to the Skills table above, and register it in `package.json` under the `skills` map.
++- **Versioning**: the canonical version lives in `genotools.yaml` (`version` field). The same value must appear in `pyproject.toml` (`project.version`), `package.json` (`version`), and `geno_notes/__init__.py` (`__version__`). Bump the version whenever skills are added, removed, or behavior changes. Keep all four files in sync.
+ 
+ ## Architecture
+ 
+diff --git a/README.md b/README.md
+index 4dcf827..b43f06b 100644
+--- a/README.md
++++ b/README.md
+@@ -44,20 +44,32 @@ Use `--global` or `--project` on any command to override. Use `--all` on reads t
+ 
+ ```
+ geno-notes/
+-├── package.json          # Vercel Skills manifest
++├── package.json          # skills manifest
+ ├── GENO.md               # agent instructions (canonical)
+ ├── CLAUDE.md             # agent shim → GENO.md
+-├── install.sh            # installer (venv, symlinks, global scope)
++├── genotools.yaml        # geno-tools install manifest
+ ├── pyproject.toml        # Python package metadata
+ ├── skills/
+ │   ├── geno-notes/
+ │   │   └── SKILL.md      # umbrella skill definition
++│   ├── geno-notes-tasks/
++│   │   └── SKILL.md      # sub-skill: task lifecycle
++│   ├── geno-notes-inbox/
++│   │   └── SKILL.md      # sub-skill: inbox management
++│   ├── geno-notes-search/
++│   │   └── SKILL.md      # sub-skill: search and reindex
++│   ├── geno-notes-workspace/
++│   │   └── SKILL.md      # sub-skill: scope inspection
+ │   ├── geno-notes-wiki-compile/
+ │   │   └── SKILL.md      # sub-skill: compile wiki
+ │   ├── geno-notes-wiki-lint/
+ │   │   └── SKILL.md      # sub-skill: lint wiki
+-│   └── geno-notes-sites-generate/
+-│       └── SKILL.md      # sub-skill: generate site
++│   ├── geno-notes-sites-generate/
++│   │   └── SKILL.md      # sub-skill: generate site
++│   ├── geno-notes-vault-generate/
++│   │   └── SKILL.md      # sub-skill: generate Obsidian vault
++│   └── geno-notes-init/
++│       └── SKILL.md      # sub-skill: initialize wiki
+ ├── geno_notes/           # Python CLI package
+ │   ├── __init__.py
+ │   ├── cli.py
+diff --git a/SKILL.md b/SKILL.md
+index 9e140c8..1f985fe 100644
+--- a/SKILL.md
++++ b/SKILL.md
+@@ -23,6 +23,12 @@ chunked journal files, and two coexisting storage scopes.
+ | Skill | Slash command | Description |
+ |-------|--------------|-------------|
+ | geno-notes | /geno-notes | Manage tasks, journal entries, plans across global and project scopes |
++| geno-notes-tasks | /geno-notes-tasks | Task lifecycle — add, start, done, abandon, list, show |
++| geno-notes-inbox | /geno-notes-inbox | Inbox management — quick capture, triage, promote between scopes |
++| geno-notes-search | /geno-notes-search | Search notes and reindex the wiki |
++| geno-notes-workspace | /geno-notes-workspace | Inspect scope, print paths, emit context bundles |
+ | geno-notes-wiki-compile | /geno-notes-wiki-compile | Compile primary sources into wiki pages |
+ | geno-notes-wiki-lint | /geno-notes-wiki-lint | Health-check the wiki against primary sources |
+ | geno-notes-sites-generate | /geno-notes-sites-generate | Generate a MkDocs Material website from notes |
++| geno-notes-vault-generate | /geno-notes-vault-generate | Generate an Obsidian vault from notes |
++| geno-notes-init | /geno-notes-init | Initialize a wiki or report its schema version |
+diff --git a/geno_notes/__init__.py b/geno_notes/__init__.py
+index af36085..1504df3 100644
+--- a/geno_notes/__init__.py
++++ b/geno_notes/__init__.py
+@@ -1,4 +1,4 @@
+ """geno-notes — project wiki with two-scope storage."""
+ 
+-__version__ = "0.2.0"
++__version__ = "0.1.0"
+ SCHEMA_VERSION = "0.2.0"
+diff --git a/package.json b/package.json
+index 8b8256c..54a7b9c 100644
+--- a/package.json
++++ b/package.json
+@@ -4,6 +4,10 @@
+   "description": "Project journal — tasks, timestamped journal entries, plans with two-scope (global + per-project) storage",
+   "skills": {
+     "geno-notes": "skills/geno-notes",
++    "geno-notes-tasks": "skills/geno-notes-tasks",
++    "geno-notes-inbox": "skills/geno-notes-inbox",
++    "geno-notes-search": "skills/geno-notes-search",
++    "geno-notes-workspace": "skills/geno-notes-workspace",
+     "geno-notes-wiki-compile": "skills/geno-notes-wiki-compile",
+     "geno-notes-wiki-lint": "skills/geno-notes-wiki-lint",
+     "geno-notes-sites-generate": "skills/geno-notes-sites-generate",
+diff --git a/skills/geno-notes-inbox/SKILL.md b/skills/geno-notes-inbox/SKILL.md
+new file mode 100644
+index 0000000..7ae5280
+--- /dev/null
++++ b/skills/geno-notes-inbox/SKILL.md
+@@ -0,0 +1,56 @@
++---
++name: geno-notes-inbox
++description: >-
++  Manage the geno-notes inbox — quick-capture items, triage and promote them to
++  tasks, or discard them. Also handles promoting tasks between global and project scopes.
++  Use when user says /geno-notes-inbox, wants to capture a quick note to inbox,
++  triage inbox items, or promote a task between scopes.
++argument-hint: "<inbox|triage|promote> [args...]"
++allowed-tools: "Bash(geno-notes *) Bash(~/.local/bin/geno-notes *) Bash(~/.geno/venv/bin/geno-notes *)"
++license: MIT
++metadata:
++  author: 42euge
++  version: "0.1.0"
++---
++
++# geno-notes-inbox — Inbox Management
++
++Capture quick ideas to inbox, triage them into tasks, or promote tasks between scopes.
++
++## Commands
++
++Parse the user's `$ARGUMENTS` and dispatch to the appropriate CLI subcommand.
++
++### `/geno-notes-inbox "<text>"`
++Quick-capture a free-floating note to `inbox.md`.
++```bash
++geno-notes inbox "<text>" [--global|--project]
++```
++
++### `/geno-notes-inbox triage`
++Interactively walk inbox items — promote each to a task, or discard.
++```bash
++geno-notes triage [--global|--project]
++```
++
++### `/geno-notes-inbox promote <pattern> [--to global|project]`
++Move a task (and its plan file, if any) between global and project scopes.
++```bash
++geno-notes promote <pattern> [--to global|project] [--global|--project]
++```
++
++## Scope flags
++
++All commands accept `--global` or `--project` to override active scope.
++
++## Completion
++
++When this skill finishes, emit a trace:
++
++```bash
++geno-trace emit \
++  --skill geno-notes-inbox \
++  --status <success|failure|abandoned> \
++  --tool-calls <approximate count> \
++  --errors <count of tool/command errors>
++```
+diff --git a/skills/geno-notes-search/SKILL.md b/skills/geno-notes-search/SKILL.md
+new file mode 100644
+index 0000000..5254733
+--- /dev/null
++++ b/skills/geno-notes-search/SKILL.md
+@@ -0,0 +1,52 @@
++---
++name: geno-notes-search
++description: >-
++  Search and reindex geno-notes content — grep across tasks, journal, plans, and
++  inbox, or regenerate the index files after manual edits.
++  Use when user says /geno-notes-search, wants to search notes, find tasks by content,
++  or reindex the wiki after hand-editing files.
++argument-hint: "<search|reindex> [args...]"
++allowed-tools: "Bash(geno-notes *) Bash(~/.local/bin/geno-notes *) Bash(~/.geno/venv/bin/geno-notes *)"
++license: MIT
++metadata:
++  author: 42euge
++  version: "0.1.0"
++---
++
++# geno-notes-search — Search and Reindex
++
++Search across all notes content, or regenerate the index files.
++
++## Commands
++
++Parse the user's `$ARGUMENTS` and dispatch to the appropriate CLI subcommand.
++
++### `/geno-notes-search <query> [--all]`
++Plain-text grep across tasks, journal, plans, and inbox.
++```bash
++geno-notes search <query> [--all] [--global|--project]
++```
++
++Returns matching lines with scope, file path, line number, and content.
++
++### `/geno-notes-search reindex`
++Regenerate `index.md` and `tasks/_index.md`. The CLI reindexes automatically on every mutation — run manually only after hand-editing task files.
++```bash
++geno-notes reindex [--global|--project]
++```
++
++## Scope flags
++
++All commands accept `--global` or `--project` to override active scope. `search` also accepts `--all` to union both scopes.
++
++## Completion
++
++When this skill finishes, emit a trace:
++
++```bash
++geno-trace emit \
++  --skill geno-notes-search \
++  --status <success|failure|abandoned> \
++  --tool-calls <approximate count> \
++  --errors <count of tool/command errors>
++```
+diff --git a/skills/geno-notes-tasks/SKILL.md b/skills/geno-notes-tasks/SKILL.md
+new file mode 100644
+index 0000000..9f2f743
+--- /dev/null
++++ b/skills/geno-notes-tasks/SKILL.md
+@@ -0,0 +1,74 @@
++---
++name: geno-notes-tasks
++description: >-
++  Manage tasks in the geno-notes journal — create, activate, complete, abandon,
++  list, and show tasks across global and project scopes.
++  Use when user says /geno-notes-tasks, wants to add, start, done, abandon,
++  list, or show tasks, or needs to manage the task lifecycle.
++argument-hint: "<add|start|done|abandon|list|show> [args...]"
++allowed-tools: "Bash(geno-notes *) Bash(~/.local/bin/geno-notes *) Bash(~/.geno/venv/bin/geno-notes *)"
++license: MIT
++metadata:
++  author: 42euge
++  version: "0.1.0"
++---
++
++# geno-notes-tasks — Task Lifecycle
++
++Manage tasks across the task lifecycle: create, activate, complete, abandon, list, and inspect.
++
++## Commands
++
++Parse the user's `$ARGUMENTS` and dispatch to the appropriate CLI subcommand.
++
++### `/geno-notes-tasks add "<description>" [--tag T]`
++Create a new task in Backlog.
++```bash
++geno-notes add "<description>" [--tag T] [--global|--project]
++```
++
++### `/geno-notes-tasks start <pattern>`
++Activate a task (Backlog → Active). Fuzzy-matches on id, slug, or title.
++```bash
++geno-notes start <pattern> [--global|--project]
++```
++
++### `/geno-notes-tasks done <pattern>`
++Complete a task.
++```bash
++geno-notes done <pattern> [--global|--project]
++```
++
++### `/geno-notes-tasks abandon <pattern>`
++Abandon a task.
++```bash
++geno-notes abandon <pattern> [--global|--project]
++```
++
++### `/geno-notes-tasks list [--status S] [--all]`
++List tasks in the active scope.
++```bash
++geno-notes list [--status active|backlog|done|abandoned] [--json] [--all] [--global|--project]
++```
++
++### `/geno-notes-tasks show <pattern> [--all]`
++Render a task file and its journal refs.
++```bash
++geno-notes show <pattern> [--all] [--global|--project]
++```
++
++## Scope flags
++
++All commands accept `--global` or `--project` to override active scope. Read commands (`list`, `show`) also accept `--all` to union both scopes.
++
++## Completion
++
++When this skill finishes, emit a trace:
++
++```bash
++geno-trace emit \
++  --skill geno-notes-tasks \
++  --status <success|failure|abandoned> \
++  --tool-calls <approximate count> \
++  --errors <count of tool/command errors>
++```
+diff --git a/skills/geno-notes-workspace/SKILL.md b/skills/geno-notes-workspace/SKILL.md
+new file mode 100644
+index 0000000..b800800
+--- /dev/null
++++ b/skills/geno-notes-workspace/SKILL.md
+@@ -0,0 +1,59 @@
++---
++name: geno-notes-workspace
++description: >-
++  Inspect and configure the geno-notes workspace — show the active scope and
++  both directory paths, print the active scope directory, and emit a curated
++  context bundle for skill execution.
++  Use when user says /geno-notes-workspace, wants to check or set the active scope,
++  print paths, or get a structured context bundle for automation.
++argument-hint: "<scope|path|context> [args...]"
++allowed-tools: "Bash(geno-notes *) Bash(~/.local/bin/geno-notes *) Bash(~/.geno/venv/bin/geno-notes *)"
++license: MIT
++metadata:
++  author: 42euge
++  version: "0.1.0"
++---
++
++# geno-notes-workspace — Workspace Configuration
++
++Inspect scope state and emit context bundles for automation.
++
++## Commands
++
++Parse the user's `$ARGUMENTS` and dispatch to the appropriate CLI subcommand.
++
++### `/geno-notes-workspace scope`
++Print the active scope name plus both scope directory paths.
++```bash
++geno-notes scope
++```
++
++### `/geno-notes-workspace path [--global|--project]`
++Print the active scope's directory path (useful for scripting).
++```bash
++geno-notes path [--global|--project]
++```
++
++### `/geno-notes-workspace context [--skill S] [--task T] [--json] [--all]`
++Emit a curated context bundle: active tasks, recent journal entries (last 7 days), relevant synthesis pages, plan for focused task, and skill health card.
++```bash
++geno-notes context [--skill SKILL_NAME] [--task TASK_PATTERN] [--json] [--all] [--global|--project]
++```
++
++Use `--json` for programmatic consumption. Use `--skill` to include the health card for a specific skill. Use `--task` to focus on a single task's context.
++
++## Scope flags
++
++All commands accept `--global` or `--project` to override active scope. `context` also accepts `--all` to union both scopes.
++
++## Completion
++
++When this skill finishes, emit a trace:
++
++```bash
++geno-trace emit \
++  --skill geno-notes-workspace \
++  --status <success|failure|abandoned> \
++  --tool-calls <approximate count> \
++  --errors <count of tool/command errors>
++```
+diff --git a/skills/geno-notes/SKILL.md b/skills/geno-notes/SKILL.md
+index b9d7940..d17077b 100644
+--- a/skills/geno-notes/SKILL.md
++++ b/skills/geno-notes/SKILL.md
+@@ -39,10 +39,15 @@ Any command takes `--global` or `--project` to override. Read commands take `--a
+ 
+ | Skill | Slash command | Description |
+ |-------|--------------|-------------|
++| geno-notes-tasks | /geno-notes-tasks | Task lifecycle — add, start, done, abandon, list, show |
++| geno-notes-inbox | /geno-notes-inbox | Inbox management — quick capture, triage, promote between scopes |
++| geno-notes-search | /geno-notes-search | Search notes and reindex the wiki |
++| geno-notes-workspace | /geno-notes-workspace | Inspect scope, print paths, emit context bundles |
+ | geno-notes-init | /geno-notes-init | Initialize a wiki or report its version |
+ | geno-notes-wiki-compile | /geno-notes-wiki-compile | Compile primary sources into synthesis pages |
+ | geno-notes-wiki-lint | /geno-notes-wiki-lint | Health-check synthesis pages against primary sources |
+ | geno-notes-sites-generate | /geno-notes-sites-generate | Generate a MkDocs Material website from notes |
++| geno-notes-vault-generate | /geno-notes-vault-generate | Generate an Obsidian vault from notes |
+ 
+ ## Commands
+ 
+-- 
+2.43.0
+


### PR DESCRIPTION
## Satellite Repo Compliance Audit — 2026-06-12

Automated full 12-section compliance audit via `geno-audit` on all 5 satellite repos.
Patches in `.audit-patches-2026-06-12/` are ready to apply with `git am` per the README.

> **Note:** The git proxy in this session is scoped to `geno-tools` only, so patches cannot be pushed directly to the satellite repos. Apply each patch manually:
> ```bash
> git clone https://github.com/42euge/<repo>
> cd <repo>
> git checkout -b chore/geno-audit-compliance
> git am .audit-patches-2026-06-12/<repo>.patch
> git push -u origin chore/geno-audit-compliance
> # open PR on GitHub
> ```

---

## Summary

| Repo | PASS | FAIL | WARN | INFO | Status |
|------|------|------|------|------|--------|
| geno-tools | — | — | — | — | skipped — PR #48 open, up to date |
| geno-iso | 34 | 0 | 5 fixed | 1 | patches ready |
| geno-mine | 9 | 0 | 11 fixed | 1 | patches ready |
| geno-agents | 8 | 3 fixed | 4 fixed | 1 | patches ready |
| geno-dev | 9 | 1 fixed | 8 (4 fixed) | 1 | patches ready |
| geno-notes | 9 | 2 fixed | 2 (1 fixed) | 1 | patches ready |

---

## Full Audit Reports

### geno-iso

**PASS: 34 | FAIL: 0 | WARN: 5 fixed | INFO: 1**

| # | Section | Result | Notes |
|---|---------|--------|-------|
| 1 | .geno Directory | PASS | `.geno/` and `CLAUDE.local.md` not tracked |
| 2 | Manifest | PASS | name=geno-iso, version=0.1.0, description present |
| 3 | Versioning | PASS | genotools.yaml, pyproject.toml, package.json, SKILL.md, __init__.py all at 0.1.0 |
| 4 | Umbrella SKILL.md | PASS | name, description, allowed-tools, metadata all present |
| 5 | Skill Nomenclature | PASS | 8 skill dirs, all have SKILL.md; 9 CLI subcmds, 7 sub-skill dirs |
| 6 | Agent Instruction Files | WARN→fixed | CLAUDE/AGENTS/GEMINI.md replaced with thin pointers; versioning subsection added to Conventions |
| 7 | Documentation | PASS | docs/, index.md, getting-started.md, mkdocs.yml (Material) all present |
| 8 | Repo Hygiene | PASS | README.md, LICENSE present |
| 9 | Agent-Agnostic Language | PASS | No exclusive framing found |
| 10 | Installation Compliance | PASS | No `npx skills add` user-facing instructions |
| 11 | Command Prefix Aliasing | WARN→fixed | `/gt-iso-containers-run` in GENO.md fixed to canonical form |
| 12 | Single Source of Truth | WARN→fixed | "Agent instruction files" and "Adding a new skill" ecosystem restatements removed from GENO.md |

**Files changed:** CLAUDE.md, AGENTS.md, GEMINI.md, GENO.md

**Unfixable:** Global gitignore INFO (machine-local, can't be set here)

---

### geno-mine

**PASS: 9 | FAIL: 0 | WARN: 11 fixed | INFO: 1**

| # | Section | Result | Notes |
|---|---------|--------|-------|
| 1 | .geno Directory | PASS | Clean |
| 2 | Manifest | PASS | name=geno-mine, version=0.1.0, description present |
| 3 | Versioning | PASS | All files at 0.1.0 |
| 4 | Umbrella SKILL.md | PASS | All fields present |
| 5 | Skill Nomenclature | WARN→fixed | Created skills/geno-mine-backfill/SKILL.md (backfill CLI subcommand had no corresponding skill) |
| 6 | Agent Instruction Files | WARN→fixed | AGENTS.md + GEMINI.md created; full Conventions section added (prefix aliasing, adding skills, versioning) |
| 7 | Documentation | PASS | All required docs present |
| 8 | Repo Hygiene | WARN→fixed | LICENSE created (MIT 2025) |
| 9 | Agent-Agnostic Language | WARN→fixed | "Claude Code session transcripts" → "agent session transcripts" in SKILL.md, GENO.md, docs |
| 10 | Installation Compliance | PASS | Clean |
| 11 | Command Prefix Aliasing | PASS | No /gt- references |
| 12 | Single Source of Truth | PASS | No ecosystem restatements |

**Files changed:** AGENTS.md (created), GEMINI.md (created), LICENSE (created), GENO.md, docs/getting-started.md, skills/geno-mine/SKILL.md, skills/geno-mine-backfill/SKILL.md (created)

---

### geno-agents

**PASS: 8 | FAIL: 3 fixed | WARN: 4 fixed | INFO: 1**

| # | Section | Result | Notes |
|---|---------|--------|-------|
| 1 | .geno Directory | FAIL→fixed | `.geno-agents` was tracked — removed from git, added to .gitignore |
| 2 | Manifest | WARN→fixed | genotools.yaml `name: agents` → `name: geno-agents` |
| 3 | Versioning | PASS | All files at 0.1.0 |
| 4 | Umbrella SKILL.md | FAIL→fixed | Root SKILL.md description had `/gt-supercharge` |
| 5 | Skill Nomenclature | PASS | 2 sub-skill dirs for 9 CLI subcmds (acceptable) |
| 6 | Agent Instruction Files | WARN→fixed | Versioning guidance added to GENO.md Conventions |
| 7 | Documentation | PASS | All present |
| 8 | Repo Hygiene | PASS | README.md, LICENSE present |
| 9 | Agent-Agnostic Language | PASS | Multi-agent listing already in docs |
| 10 | Installation Compliance | PASS | Clean |
| 11 | Command Prefix Aliasing | FAIL→fixed | 5 SKILL.md files had `/gt-` aliases; GENO.md had `/gt-` example — all fixed to `/geno-` |
| 12 | Single Source of Truth | PASS | Clean |

**Files changed:** .geno-agents (deleted), .gitignore, SKILL.md (root), genotools.yaml, GENO.md, skills/geno-agents/SKILL.md, skills/geno-agents-supercharge/SKILL.md, skills/geno-agents-tasks-start/SKILL.md

---

### geno-dev

**PASS: 9 | FAIL: 1 fixed | WARN: 8 (4 fixed, 4 unfixable) | INFO: 1**

| # | Section | Result | Notes |
|---|---------|--------|-------|
| 1 | .geno Directory | WARN (unfixable) | `.geno-agents` also untracked (runtime file); global gitignore not present |
| 2 | Manifest | PASS | Clean |
| 3 | Versioning | PASS | All files at 0.1.0 |
| 4 | Umbrella SKILL.md | WARN→fixed | `allowed-tools` field added to frontmatter |
| 5 | Skill Nomenclature | WARN→fixed | sessions-remote added to GENO.md skills table + repo structure; stale loop skill refs removed from SKILL.md description and Commands table |
| 6 | Agent Instruction Files | WARN→fixed | Versioning guidance added to GENO.md Conventions |
| 7 | Documentation | PASS | All present |
| 8 | Repo Hygiene | PASS | README.md, LICENSE present |
| 9 | Agent-Agnostic Language | PASS | Existing docs already list all supported CLIs |
| 10 | Installation Compliance | PASS | Clean |
| 11 | Command Prefix Aliasing | FAIL→fixed | `/gt-pr` alias removed from geno-dev-prs-check SKILL.md description |
| 12 | Single Source of Truth | PASS | Clean |

**Files changed:** .geno-agents (deleted), .gitignore, SKILL.md (root), GENO.md, README.md, skills/geno-dev-prs-check/SKILL.md

**Unfixable:** Global gitignore INFO; sessions-remote absent from umbrella skills/geno-dev/SKILL.md commands list (intentionally curated)

---

### geno-notes

**PASS: 9 | FAIL: 2 fixed | WARN: 2 (1 fixed) | INFO: 1**

| # | Section | Result | Notes |
|---|---------|--------|-------|
| 1 | .geno Directory | PASS | Clean |
| 2 | Manifest | PASS | Clean |
| 3 | Versioning | FAIL→fixed | `geno_notes/__init__.py` had `__version__ = "0.2.0"` — synced to 0.1.0 |
| 4 | Umbrella SKILL.md | PASS | All fields present |
| 5 | Skill Nomenclature | FAIL→fixed | 20 CLI subcommands, only umbrella skill dir — monolithic CLI FAIL; created 4 sub-skillset dirs: geno-notes-tasks, geno-notes-inbox, geno-notes-search, geno-notes-workspace |
| 6 | Agent Instruction Files | WARN→fixed | Versioning guidance added to GENO.md Conventions (all 4 version files listed) |
| 7 | Documentation | PASS | All present; docs/assets/icon.png absent (INFO only) |
| 8 | Repo Hygiene | PASS | README.md, LICENSE present |
| 9 | Agent-Agnostic Language | PASS | Existing docs already use supported-CLI listing |
| 10 | Installation Compliance | PASS | Clean |
| 11 | Command Prefix Aliasing | PASS | No /gt- references |
| 12 | Single Source of Truth | PASS | Conventions are repo-specific, not ecosystem restatements |

**Files changed:** geno_notes/__init__.py, skills/geno-notes-tasks/SKILL.md (created), skills/geno-notes-inbox/SKILL.md (created), skills/geno-notes-search/SKILL.md (created), skills/geno-notes-workspace/SKILL.md (created), skills/geno-notes/SKILL.md, SKILL.md (root), GENO.md, package.json, README.md

**Unfixable:** docs/assets/icon.png missing (optional, generate via /geno-icons)

---

## Unfixable items across all repos

- **All repos — Section 1 INFO**: `~/.config/git/ignore` does not exist on this machine. Add `.geno/` and `CLAUDE.local.md` there (not in any project `.gitignore`):
  ```bash
  git config --global core.excludesFile ~/.config/git/ignore
  printf '.geno/\nCLAUDE.local.md\n' >> ~/.config/git/ignore
  ```

https://claude.ai/code/session_01VMsXYnkCiCgymeU4cc8wZy

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMsXYnkCiCgymeU4cc8wZy)_