### PR TITLE
fix(plugin): enumerate category dirs in manifest skills array

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "geno-tools",
-  "description": "Meta-CLI for installing and managing geno-* skillsets — the geno ecosystem orchestrator",
-  "version": "0.1.0",
+  "description": "Meta-CLI for installing and managing geno-* skillsets \u2014 the geno ecosystem orchestrator",
+  "version": "0.3.0",
   "author": {
     "name": "42euge",
     "url": "https://github.com/42euge"
@@ -15,6 +15,13 @@
     "meta-cli",
     "geno-ecosystem"
   ],
-  "skills": "./skills",
+  "skills": [
+    "./skills",
+    "./skills/audit",
+    "./skills/author",
+    "./skills/manager",
+    "./skills/meta/ecosystem",
+    "./skills/meta/harness"
+  ],
   "hooks": "./geno_tools/hooks/hooks.json"
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "geno-tools",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "description": "Meta-CLI for installing and managing geno-* skillsets",
   "author": {
     "name": "42euge"
@@ -14,7 +14,14 @@
     "meta-cli",
     "geno-ecosystem"
   ],
-  "skills": "./skills/",
+  "skills": [
+    "./skills",
+    "./skills/audit",
+    "./skills/author",
+    "./skills/manager",
+    "./skills/meta/ecosystem",
+    "./skills/meta/harness"
+  ],
   "interface": {
     "displayName": "geno-tools",
     "shortDescription": "Install and manage geno-* skillsets for any coding agent",

--- a/geno_tools/scripts/bootstrap.sh
+++ b/geno_tools/scripts/bootstrap.sh
@@ -33,6 +33,13 @@ if [[ ! -e "${target_file}" && -f "${default_config}" ]]; then
   cp "${default_config}" "${target_file}"
 fi
 
+# Keep each plugin manifest's `skills` array pointed at every category dir, so
+# Claude Code's depth-1 plugin loader finds nested skills. Quiet + idempotent.
+gen_skills="${plugin_root}/geno_tools/scripts/gen_plugin_skills.py"
+if [[ -f "${gen_skills}" ]] && command -v python3 >/dev/null 2>&1; then
+  python3 "${gen_skills}" >>"${log_file}" 2>&1 || true
+fi
+
 if command -v geno-tools >/dev/null 2>&1; then
   exit 0
 fi

--- a/geno_tools/scripts/gen_plugin_skills.py
+++ b/geno_tools/scripts/gen_plugin_skills.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Regenerate the `skills` array in every plugin manifest.
+
+Claude Code's plugin loader scans each path in a manifest's `skills` field only
+ONE level deep (`<dir>/<name>/SKILL.md`). Our skills use category nesting
+(`skills/<category>/<name>/SKILL.md`, arbitrarily deep), so a single
+`"skills": "./skills"` would miss everything below the top level.
+
+This walks `skills/`, finds every directory that DIRECTLY contains a
+`<name>/SKILL.md`, and writes that list (relative, `./`-prefixed, sorted) into
+the `skills` field of each plugin manifest. Run it whenever categories change
+(the bootstrap runs it on install). Idempotent.
+
+Usage: python3 geno_tools/scripts/gen_plugin_skills.py [--check]
+  --check  exit 1 if any manifest is out of date (for CI), writing nothing.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent.parent
+SKILLS = REPO / "skills"
+
+# Manifests whose `skills` field must enumerate the category dirs.
+MANIFESTS = [
+    ".claude-plugin/plugin.json",
+    ".codex-plugin/plugin.json",
+    "plugin.json",
+]
+
+
+def skill_parent_dirs() -> list[str]:
+    """Dirs that directly contain a `<name>/SKILL.md`, as `./`-relative paths."""
+    parents = set()
+    for skill_md in SKILLS.rglob("SKILL.md"):
+        # skill_md = .../skills/<...>/<name>/SKILL.md; parent.parent is the dir
+        # the loader must be pointed at so it finds <name>/ one level down.
+        parent = skill_md.parent.parent
+        rel = parent.relative_to(REPO)
+        parents.add("./" + str(rel))
+    return sorted(parents)
+
+
+def main(argv=None) -> int:
+    argv = argv if argv is not None else sys.argv[1:]
+    check = "--check" in argv
+    desired = skill_parent_dirs()
+    stale = []
+    for rel in MANIFESTS:
+        path = REPO / rel
+        if not path.exists():
+            continue
+        data = json.loads(path.read_text())
+        if data.get("skills") == desired:
+            continue
+        stale.append(rel)
+        if not check:
+            data["skills"] = desired
+            path.write_text(json.dumps(data, indent=2) + "\n")
+    if check:
+        if stale:
+            print("stale skills array in: " + ", ".join(stale), file=sys.stderr)
+            return 1
+        print("plugin skills arrays up to date")
+        return 0
+    if stale:
+        print(f"updated skills array ({len(desired)} paths) in: {', '.join(stale)}")
+    else:
+        print("plugin skills arrays already up to date")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "geno-tools",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Meta-CLI for installing and managing geno-* skillsets",
   "author": {
     "name": "42euge",
@@ -9,5 +9,12 @@
   "homepage": "https://42euge.github.io/geno-tools",
   "repository": "https://github.com/42euge/geno-tools",
   "license": "MIT",
-  "skills": "./skills"
+  "skills": [
+    "./skills",
+    "./skills/audit",
+    "./skills/author",
+    "./skills/manager",
+    "./skills/meta/ecosystem",
+    "./skills/meta/harness"
+  ]
 }

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -64,9 +64,14 @@ class TestPluginJson:
         assert skills_path, "plugin.json must declare a skills path"
 
     def test_skills_dir_exists(self, manifest):
-        skills_path = manifest.get("skills", "./skills")
-        skills_dir = REPO_ROOT / skills_path
-        assert skills_dir.is_dir(), f"skills dir {skills_dir} does not exist"
+        # `skills` may be a single path or an array of category dirs (each
+        # scanned one level deep by the plugin loader).
+        skills_paths = manifest.get("skills", "./skills")
+        if isinstance(skills_paths, str):
+            skills_paths = [skills_paths]
+        for skills_path in skills_paths:
+            skills_dir = REPO_ROOT / skills_path
+            assert skills_dir.is_dir(), f"skills dir {skills_dir} does not exist"
 
     def test_version_matches_marketplace(self, manifest):
         mp = json.loads((REPO_ROOT / ".claude-plugin" / "marketplace.json").read_text())

--- a/tests/test_plugin_skills_array.py
+++ b/tests/test_plugin_skills_array.py
@@ -1,0 +1,60 @@
+"""The plugin manifests' `skills` arrays must enumerate every category dir.
+
+Claude Code's plugin loader scans each `skills` path only one level deep. With
+category nesting (`skills/<category>/<name>/SKILL.md`), the manifests must list
+every directory that directly contains a `<name>/SKILL.md`, or Claude Code loads
+zero nested skills. `gen_plugin_skills.py` regenerates the list; this test fails
+if any committed manifest is out of date.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GEN = REPO_ROOT / "geno_tools" / "scripts" / "gen_plugin_skills.py"
+MANIFESTS = [
+    ".claude-plugin/plugin.json",
+    ".codex-plugin/plugin.json",
+    "plugin.json",
+]
+
+
+def _load_gen():
+    spec = importlib.util.spec_from_file_location("gen_plugin_skills", GEN)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_generator_check_passes():
+    """Committed manifests match what the generator would write (CI gate)."""
+    gen = _load_gen()
+    assert gen.main(["--check"]) == 0, (
+        "Plugin manifest skills array is stale — run "
+        "`python3 geno_tools/scripts/gen_plugin_skills.py`."
+    )
+
+
+def test_every_category_dir_listed():
+    gen = _load_gen()
+    desired = gen.skill_parent_dirs()
+    # umbrella + every category that holds leaf skills
+    assert "./skills" in desired
+    for manifest in MANIFESTS:
+        path = REPO_ROOT / manifest
+        if not path.exists():
+            continue
+        skills = json.loads(path.read_text()).get("skills")
+        assert skills == desired, f"{manifest} skills array out of date"
+
+
+def test_listed_dirs_have_skill_children():
+    """Every path in the array directly contains at least one <name>/SKILL.md."""
+    gen = _load_gen()
+    for rel in gen.skill_parent_dirs():
+        d = REPO_ROOT / rel.lstrip("./")
+        children = [c for c in d.iterdir() if (c / "SKILL.md").exists()]
+        assert children, f"{rel} lists no <name>/SKILL.md children"


### PR DESCRIPTION
**Fixes `/plugin install` loading 0 skills.** After #64's category-nesting, Claude Code's plugin loader (which scans each `skills` path only **one level deep**) saw `"skills": "./skills"`, found only the category dirs (`manager/`, `meta/`, … which have no SKILL.md of their own), and loaded nothing — `/plugin list` showed `0 skills · 1 error`.

## Root cause (verified against docs)
Claude Code plugin manifests load skills at `<skills-path>/<name>/SKILL.md` — depth-1 only, no recursion. Our skills are `skills/<category>/<name>/SKILL.md`. The manifest `skills` field **accepts an array** of dirs, each scanned depth-1 — so we enumerate the category dirs.

## Fix (on-disk tree from #64 unchanged)
- **`geno_tools/scripts/gen_plugin_skills.py`** — walks `skills/`, finds every dir that directly contains a `<name>/SKILL.md`, writes that sorted list into each manifest's `skills` array. Idempotent, `--check` mode for CI.
- Regenerated in **`.claude-plugin`, `.codex-plugin`, `plugin.json`** → `[./skills, ./skills/audit, ./skills/author, ./skills/manager, ./skills/meta/ecosystem, ./skills/meta/harness]`.
- **`bootstrap.sh`** runs the generator on session start, so the array stays correct as categories are added/removed.
- **`tests/test_plugin_skills_array.py`** gates committed manifests vs the generator; fixed `test_skills_dir_exists` to accept an array.
- Bumped manifest versions `0.1.0/0.2.0 → 0.3.0` (stale vs `genotools.yaml` — this is why `/plugin list` showed v0.1.0).

## Tests
146 pass; the 2 failures are pre-existing on main (missing `scripts/init-geno-dir.sh` + session hook), unrelated.

## After merge
Reinstall cleanly: `/plugin marketplace remove geno-tools` → `add 42euge/geno-tools` → `install` → `/reload-plugins`. Should load all 17 skills (umbrella + 16 functions) at v0.3.0.