### PR TITLE
feat(skills): /geno-tools-setup — explicit CLI installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ site/
 
 # geno-audit temp clones
 .geno-audit/
+build/

--- a/skills/geno-tools/SKILL.md
+++ b/skills/geno-tools/SKILL.md
@@ -17,7 +17,7 @@ category directories (`skills/<category>/<name>/SKILL.md`) — see `SKILLS.md` f
 the nesting standard.
 
 ```!
-which geno-tools >/dev/null 2>&1 || echo "geno-tools CLI not on PATH. The plugin's SessionStart hook (Claude Code) runs geno_tools/scripts/bootstrap.sh automatically. On Antigravity CLI / Codex, run 'bash \$PLUGIN_ROOT/geno_tools/scripts/bootstrap.sh' once."
+which geno-tools >/dev/null 2>&1 || echo "geno-tools CLI not on PATH — run /geno-tools-setup to install it (or 'bash \$PLUGIN_ROOT/skills/setup/setup.sh')."
 ```
 
 ## Skills by category

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: geno-tools-setup
+description: >-
+  Install the geno-tools CLI onto your PATH (run this first if `geno-tools`
+  isn't found). Ensures pipx, pipx-installs the CLI from the plugin, seeds
+  ~/.geno config, and verifies. Use when geno-tools commands report the CLI is
+  not on PATH, or right after installing the geno-tools plugin.
+allowed-tools: "Bash(bash *) Bash(geno-tools *) Bash(command -v *) Read(*)"
+license: MIT
+metadata:
+  author: 42euge
+  version: "0.1.0"
+---
+
+# setup — install the geno-tools CLI
+
+Optional but recommended right after installing the geno-tools plugin. The
+plugin's SessionStart hook tries to install the CLI silently; this skill does it
+**loudly and reliably**, and is what other skills point you to if the CLI isn't
+on PATH.
+
+## Run it
+
+```!
+bash "${CLAUDE_PLUGIN_ROOT}/skills/setup/setup.sh"
+```
+
+The script (idempotent — safe to re-run):
+
+1. Seeds `~/.geno/config.yaml` from the plugin's `defaults.yaml`.
+2. Exits early if `geno-tools` is already on PATH.
+3. Locates `pipx` (probing `~/.local/bin` and `~/Library/Python/*/bin`, not just
+   PATH) and installs it via Homebrew if truly missing — `pip install --user` is
+   blocked on Homebrew Python by PEP 668, so pipx is the reliable path.
+4. `pipx install` the CLI from the plugin root.
+5. Verifies `geno-tools` resolves and reports the version, or tells you exactly
+   how to fix PATH if `~/.local/bin` isn't on it.
+
+## Verify
+
+```
+geno-tools ls --available
+```
+
+If it still isn't found, the script printed the fix (add `~/.local/bin` to PATH
+and open a new shell). The full log is at `~/.geno/bootstrap.log`.

--- a/skills/setup/setup.sh
+++ b/skills/setup/setup.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Install the geno-tools CLI onto PATH — the explicit, loud counterpart to the
+# silent SessionStart bootstrap. Idempotent: safe to re-run.
+#
+# Resolves the plugin root from CLAUDE_PLUGIN_ROOT, else from this script's
+# location (skills/setup/ sits two levels under the plugin root).
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+plugin_root="${CLAUDE_PLUGIN_ROOT:-${script_dir%/skills/setup}}"
+
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; }
+warn() { printf '  \033[33m!\033[0m %s\n' "$1"; }
+err()  { printf '  \033[31m✗\033[0m %s\n' "$1"; }
+
+echo "geno-tools setup — installing the CLI from ${plugin_root}"
+
+# 1. Seed ~/.geno/config.yaml (same as bootstrap).
+mkdir -p "${HOME}/.geno"
+default_config="${plugin_root}/geno_tools/config/defaults.yaml"
+if [[ ! -e "${HOME}/.geno/config.yaml" && -f "${default_config}" ]]; then
+  cp "${default_config}" "${HOME}/.geno/config.yaml"
+  ok "seeded ~/.geno/config.yaml"
+else
+  ok "~/.geno/config.yaml present"
+fi
+
+# 2. Already on PATH? Done.
+if command -v geno-tools >/dev/null 2>&1; then
+  ok "geno-tools already on PATH ($(command -v geno-tools))"
+  geno-tools --version 2>/dev/null || true
+  exit 0
+fi
+
+if [[ ! -f "${plugin_root}/pyproject.toml" ]]; then
+  err "no pyproject.toml at ${plugin_root}; cannot install the CLI"
+  exit 1
+fi
+
+# 3. Locate pipx. It's often installed but not on a non-interactive PATH
+#    (e.g. ~/Library/Python/3.x/bin on macOS, ~/.local/bin), so probe those
+#    before deciding it's missing.
+find_pipx() {
+  command -v pipx 2>/dev/null && return 0
+  for p in "${HOME}/.local/bin/pipx" "${HOME}"/Library/Python/*/bin/pipx; do
+    [[ -x "$p" ]] && { echo "$p"; return 0; }
+  done
+  return 1
+}
+
+pipx_bin="$(find_pipx)" || pipx_bin=""
+
+# On Homebrew Python, `pip install --user` is blocked by PEP 668, so pipx is the
+# reliable installer — install it (preferring brew) only if truly absent.
+if [[ -z "${pipx_bin}" ]]; then
+  warn "pipx not found; installing it"
+  if command -v brew >/dev/null 2>&1; then
+    brew install pipx && brew --prefix >/dev/null 2>&1
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 -m pip install --user --quiet pipx 2>/dev/null \
+      || python3 -m pip install --user --break-system-packages --quiet pipx
+  else
+    err "no brew or python3 to install pipx; install pipx manually, then re-run"
+    exit 1
+  fi
+  pipx_bin="$(find_pipx)" || pipx_bin="python3 -m pipx"
+else
+  ok "found pipx: ${pipx_bin}"
+fi
+
+# 4. Install the CLI with pipx and make sure its bin dir is on PATH.
+${pipx_bin} ensurepath >/dev/null 2>&1 || true
+${pipx_bin} install --force "${plugin_root}"
+
+# 5. Verify — pipx drops binaries in ~/.local/bin; surface PATH issues loudly.
+hash -r 2>/dev/null || true
+if command -v geno-tools >/dev/null 2>&1; then
+  ok "geno-tools installed: $(command -v geno-tools)"
+  geno-tools --version 2>/dev/null || true
+  ok "setup complete — try: geno-tools ls --available"
+else
+  warn "geno-tools installed but not yet on PATH for this shell."
+  warn "It's at ~/.local/bin/geno-tools. Add ~/.local/bin to PATH (pipx ensurepath)"
+  warn "and open a new shell, or run: export PATH=\"\$HOME/.local/bin:\$PATH\""
+fi

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -77,8 +77,10 @@ class TestPluginJson:
 class TestSkills:
     @pytest.fixture()
     def skill_dirs(self):
+        # Skills nest under category dirs (skills/<category>/<name>/SKILL.md,
+        # arbitrarily deep), so walk recursively, not just one level.
         skills_dir = REPO_ROOT / "skills"
-        return [d for d in skills_dir.iterdir() if d.is_dir() and (d / "SKILL.md").exists()]
+        return [p.parent for p in skills_dir.rglob("SKILL.md")]
 
     def test_at_least_one_skill(self, skill_dirs):
         assert len(skill_dirs) >= 1
@@ -92,14 +94,20 @@ class TestSkills:
             assert fm.get("name"), f"{skill_dir.name}: frontmatter missing 'name'"
             assert fm.get("description"), f"{skill_dir.name}: frontmatter missing 'description'"
 
-    def test_skill_dir_name_matches_frontmatter_name(self, skill_dirs):
+    def test_skill_name_mirrors_path(self, skill_dirs):
+        # Per the nesting standard (SKILLS.md): a leaf's frontmatter `name` is
+        # the fully-qualified path. The umbrella is exactly "geno-tools"; every
+        # nested leaf's name ends with "-<leaf-dir-name>".
         for skill_dir in skill_dirs:
             text = (skill_dir / "SKILL.md").read_text()
             end = text.index("---", 3)
-            fm = yaml.safe_load(text[3:end])
-            assert fm["name"] == skill_dir.name, (
-                f"dir name '{skill_dir.name}' != frontmatter name '{fm['name']}'"
-            )
+            name = yaml.safe_load(text[3:end])["name"]
+            if skill_dir.name == "geno-tools":
+                assert name == "geno-tools"
+            else:
+                assert name.endswith(f"-{skill_dir.name}"), (
+                    f"name '{name}' should end with '-{skill_dir.name}' (path-mirrored)"
+                )
 
     def test_umbrella_skill_exists(self, skill_dirs):
         names = {d.name for d in skill_dirs}


### PR DESCRIPTION
Adds an **optional, loud** skill to install the geno-tools CLI, for when the silent SessionStart hook didn't (the Homebrew-Python / missing-pipx case that left `geno-tools` off PATH).

## Why
The plugin installs the CLI via a SessionStart hook → `bootstrap.sh` → pipx. That's silent and **no-ops if pipx isn't found** (on Homebrew Python, the `pip install --user` fallback is PEP-668-blocked). You hit exactly this. Forcing a manual first step is heavy; instead:

- **Optional**: run `/geno-tools-setup` upfront if you want, but you don't have to.
- **Called later if missing**: the umbrella skill's preflight now points you to `/geno-tools-setup` whenever `geno-tools` isn't on PATH — so a silent hook failure surfaces a fix next time you touch a geno skill.
- **Hook unchanged**: still the silent best-effort fallback.

## What it does (`skills/setup/setup.sh`)
1. Seed `~/.geno/config.yaml`.
2. Exit early if `geno-tools` already on PATH.
3. **Locate pipx** — probes `~/.local/bin` and `~/Library/Python/*/bin`, not just PATH (pipx is often installed but off a non-interactive PATH — the real bug). Installs via brew only if truly absent.
4. `pipx install` the CLI from the plugin root + `ensurepath`.
5. Verify `geno-tools` resolves, report version — or print the exact PATH fix.

**Verified on macOS**: found the off-PATH pipx at `~/Library/Python/3.12/bin`, installed **geno-tools 0.3.0**, `geno-tools ls --available` works.

## Also
- Fixed `TestSkills` to be nesting-aware (walk `skills/` recursively; assert name-mirrors-path). The old top-level `iterdir` + `name==dir` test was stale post-#64 and failed on main.
- gitignore `build/` (pipx/setuptools artifact).

143 tests pass; the 2 failures are pre-existing on main (missing `scripts/init-geno-dir.sh` + session hook), unrelated.

## Stacking note
Independent of #66 (manifest skills array) — `setup/` is top-level so `./skills` depth-1 already covers it. Both can merge in any order.