### PR TITLE
feat(registry): agent-driven discovery, drop hardcoded fallback

### DIFF
--- a/geno_tools/commands.py
+++ b/geno_tools/commands.py
@@ -40,12 +40,14 @@ def dispatch(args: argparse.Namespace) -> int:
 
 def _ls(args: argparse.Namespace) -> int:
     if args.available:
-        for name, url in registry.available().items():
+        repos = registry.available()
+        if not repos:
+            print("  no skillsets discovered yet.")
+            print("  run /geno-tools-meta-ecosystem-discover to find them,")
+            print("  or install directly by git URL: geno-tools install <url>")
+            return 0
+        for name, url in sorted(repos.items()):
             print(f"  {name:<24} {url}")
-        for name, url in discovery.candidates_by_name().items():
-            if name in registry.available():
-                continue
-            print(f"  {name:<24} {url}  (discovered)")
         return 0
 
     if not paths.ROOT.exists():
@@ -191,13 +193,11 @@ def _resolve_source(name_or_source: str) -> tuple[str, str | None]:
        or name_or_source.endswith(".git"):
         return name_or_source, None
 
-    discovered = discovery.candidates_by_name()
-    if name_or_source in discovered:
-        return discovered[name_or_source], name_or_source
-
     raise SystemExit(
-        f"unknown skillset: {name_or_source} "
-        f"(not in registry, not in discovery sources, not a path, not a git URL)"
+        f"unknown skillset: {name_or_source}\n"
+        f"  not in the discovery cache, not a local path, not a git URL.\n"
+        f"  run /geno-tools-meta-ecosystem-discover to refresh the cache,\n"
+        f"  or install directly: geno-tools install <git-url>"
     )
 
 

--- a/geno_tools/registry.py
+++ b/geno_tools/registry.py
@@ -1,63 +1,82 @@
-"""Registry of geno-* skillsets — discovers repos from GitHub.
+"""Registry of geno-* skillsets — a discovery cache, not a hardcoded list.
+
+A meta-ecosystem discovers its skillsets rather than shipping a static list.
+The `meta/ecosystem/discover` skill drives an agent (web search + unauthenticated
+curl against the public GitHub API) to find geno-* repos that expose a top-level
+`SKILL.md`, and writes them to the cache below. This module only READS that
+cache — no `gh`, no token, no network of its own.
+
+Cache shape (`~/.geno/registry.json`):
+
+    {
+      "geno-loops": {"url": "https://github.com/42euge/geno-loops.git",
+                     "source": "github:42euge", "discovered": "2026-06-26T..."},
+      ...
+    }
 
 Registry keys are the full repo name (e.g. ``geno-<name>``). For backwards
 compatibility the resolver also accepts the bare slug (``<name>``).
 """
 
 import json
-import subprocess
+from pathlib import Path
 
-OWNER = "42euge"
 PREFIX = "geno-"
-EXCLUDE = {"geno-tools"}
-
-
-def _discover() -> dict[str, str]:
-    """Discover geno-* repos from the GitHub account via `gh` CLI."""
-    try:
-        r = subprocess.run(
-            ["gh", "repo", "list", OWNER,
-             "--json", "name,url",
-             "--limit", "100",
-             "--no-archived"],
-            capture_output=True, text=True, timeout=15,
-        )
-        if r.returncode != 0:
-            return {}
-        repos = json.loads(r.stdout)
-        return {
-            repo["name"]: repo["url"] + ".git"
-            for repo in repos
-            if repo["name"].startswith(PREFIX) and repo["name"] not in EXCLUDE
-        }
-    except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError):
-        return {}
-
-
-_FALLBACK: dict[str, str] = {
-    "geno-agents":   f"https://github.com/{OWNER}/geno-agents.git",
-    "geno-media":    f"https://github.com/{OWNER}/geno-media.git",
-    "geno-research": f"https://github.com/{OWNER}/geno-research.git",
-    "geno-taxes":    f"https://github.com/{OWNER}/geno-taxes.git",
-    "geno-kaggle":   f"https://github.com/{OWNER}/geno-kaggle.git",
-    "geno-dev":      f"https://github.com/{OWNER}/geno-dev.git",
-    "geno-specs":    f"https://github.com/{OWNER}/geno-specs.git",
-}
+CACHE_FILE = Path.home() / ".geno" / "registry.json"
 
 _cache: dict[str, str] | None = None
 
 
+def read_cache() -> dict[str, str]:
+    """Return ``{name: url}`` from the discovery cache, or ``{}`` if absent.
+
+    Tolerates both the rich shape ({name: {url, ...}}) the discover skill writes
+    and a plain {name: url} map.
+    """
+    if not CACHE_FILE.exists():
+        return {}
+    try:
+        data = json.loads(CACHE_FILE.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+    out: dict[str, str] = {}
+    for name, val in data.items():
+        if isinstance(val, dict):
+            url = val.get("url")
+            if url:
+                out[name] = url
+        elif isinstance(val, str):
+            out[name] = val
+    return out
+
+
+def write_cache(entries: dict) -> Path:
+    """Write the discovery cache (used by the discover skill / tests).
+
+    `entries` may map name -> url or name -> {url, source, discovered}.
+    Invalidates the in-process cache so the next ``available()`` re-reads.
+    """
+    global _cache
+    CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    CACHE_FILE.write_text(json.dumps(entries, indent=2) + "\n")
+    _cache = None
+    return CACHE_FILE
+
+
 def available() -> dict[str, str]:
+    """Return ``{name: url}`` of discoverable skillsets (from the cache).
+
+    Empty when discovery has never run — that's intentional: no fake/hardcoded
+    data. Callers should prompt the user to run the discover skill.
+    """
     global _cache
     if _cache is None:
-        _cache = _discover()
-        if not _cache:
-            _cache = dict(_FALLBACK)
+        _cache = read_cache()
     return _cache
 
 
 def resolve(name: str) -> str | None:
-    """Return the git URL for a registered skillset name, or None.
+    """Return the git URL for a discovered skillset name, or None.
 
     Accepts the canonical full repo name (e.g. ``geno-<name>``) and, for
     backwards compatibility, the bare slug (e.g. ``<name>``).

--- a/skills/meta/ecosystem/discover/SKILL.md
+++ b/skills/meta/ecosystem/discover/SKILL.md
@@ -1,20 +1,70 @@
 ---
 name: geno-tools-meta-ecosystem-discover
 description: >-
-  List candidate geno-* skillsets from configured discovery sources. Use when
-  the user wants to find installable skillsets across their orgs/registries.
-allowed-tools: "Bash(geno-tools discover *)"
+  Discover installable geno-* skillsets and write them to the geno-tools
+  registry cache. Use when the user wants to find skillsets, when
+  `geno-tools install <name>` reports a name isn't in the registry, or when
+  `geno-tools ls --available` is empty. Read-only — finds repos, never installs.
+allowed-tools: "Bash(curl *) Bash(python3 *) Bash(mkdir *) WebSearch Read(*)"
+license: MIT
 metadata:
   author: 42euge
-  version: "0.1.0"
+  version: "0.2.0"
 ---
 
-# meta/ecosystem/discover — find candidate skillsets
+# meta/ecosystem/discover — find skillsets, populate the registry
 
-```
-geno-tools discover [--dry-run]
-```
+geno-tools is a **meta-ecosystem**: it does not ship a hardcoded list of
+skillsets. This skill goes and finds them, then writes a cache the CLI reads.
+It uses **only unauthenticated `curl` + web search** — no `gh`, no token, no
+MCP — so it works on any machine. It is **read-only**: it discovers and caches,
+it never clones or installs (that's `geno-tools install`).
 
-Lists repos from `~/.geno/config.yaml` `discovery.sources` that match the
-configured prefix and carry a top-level `SKILL.md` — the candidates you can
-`geno-tools install`.
+## What to do
+
+### 1. Find the org(s) to scan
+Read `~/.geno/config.yaml` → `discovery.sources`; each `{kind: github, org: ...}`
+gives an org (default `42euge`, prefix `geno-`).
+
+### 2. List candidate repos (public GitHub API, unauthenticated)
+```bash
+curl -s "https://api.github.com/users/<org>/repos?per_page=100&type=public"
+```
+Parse the JSON; keep repos whose `name` starts with the prefix (`geno-`) and
+that are not archived. (60 req/hr unauth is ample. If rate-limited, fall back to
+**web search** of `github.com/<org>` to enumerate the repos.)
+
+### 3. Keep only real skillsets (top-level SKILL.md)
+For each candidate, confirm it exposes a root `SKILL.md`:
+```bash
+curl -s -o /dev/null -w '%{http_code}' \
+  "https://raw.githubusercontent.com/<org>/<name>/HEAD/SKILL.md"
+```
+`200` → it's a skillset; keep it. Other → drop it.
+
+### 4. Write the registry cache
+Write `~/.geno/registry.json` mapping each kept repo to its clone URL:
+```json
+{
+  "geno-loops": {
+    "url": "https://github.com/<org>/geno-loops.git",
+    "source": "github:<org>",
+    "discovered": "<ISO-8601 timestamp>"
+  }
+}
+```
+Use the helper so the shape and path stay canonical:
+```bash
+python3 -c "from geno_tools import registry; registry.write_cache(<dict>)"
+```
+(or write the JSON directly to `~/.geno/registry.json`).
+
+### 5. Report
+Print how many skillsets were discovered and that the user can now
+`geno-tools ls --available` / `geno-tools install <name>`.
+
+## Boundaries
+- **Public repos only.** Unauthenticated curl can't see private repos. Private
+  skillsets are installed directly by git URL: `geno-tools install <git-url>`.
+- **Never installs.** This skill only writes the cache. Installation is always a
+  separate, explicit `geno-tools install`.

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -176,13 +176,20 @@ class TestResolveSource:
         source, name = commands._resolve_source(url)
         assert source == url
 
-    def test_discovered_source(self, monkeypatch):
+    def test_unknown_name_points_at_discover_skill(self, monkeypatch):
+        # Not in the cache, not a path, not a URL → error names the discover skill.
         monkeypatch.setattr("geno_tools.registry._cache", {})
-        monkeypatch.setattr("geno_tools.discovery.candidates_by_name",
-                            lambda: {"geno-new": "https://github.com/42euge/geno-new.git"})
-        source, name = commands._resolve_source("geno-new")
-        assert "geno-new" in source
-        assert name == "geno-new"
+        with pytest.raises(SystemExit, match="discover"):
+            commands._resolve_source("geno-nonexistent")
+
+    def test_resolve_from_discovery_cache(self, monkeypatch):
+        # A name written to the registry cache resolves to its URL.
+        monkeypatch.setattr("geno_tools.registry._cache", {
+            "geno-loops": "https://github.com/42euge/geno-loops.git",
+        })
+        source, name = commands._resolve_source("geno-loops")
+        assert source == "https://github.com/42euge/geno-loops.git"
+        assert name == "geno-loops"
 
     def test_unknown_raises(self, monkeypatch):
         monkeypatch.setattr("geno_tools.registry._cache", {})

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,7 +1,11 @@
-"""Tests for registry resolution — names, fallback, backwards compat."""
+"""Tests for the registry — a discovery cache, no hardcoded list, no gh.
+
+The registry reads ~/.geno/registry.json (written by the discover skill). It
+ships no fallback data and never shells out. These tests point CACHE_FILE at a
+temp file and exercise read/write/resolve.
+"""
 
 import json
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -9,80 +13,70 @@ from geno_tools import registry
 
 
 @pytest.fixture(autouse=True)
-def _reset_cache():
+def _temp_cache(tmp_path, monkeypatch):
+    """Point the registry cache at a temp file; reset the in-process cache."""
+    cache = tmp_path / "registry.json"
+    monkeypatch.setattr(registry, "CACHE_FILE", cache)
     registry._cache = None
-    yield
+    yield cache
     registry._cache = None
 
 
-class TestFallback:
-    def test_fallback_used_when_gh_unavailable(self, monkeypatch):
-        monkeypatch.setattr("subprocess.run",
-                            lambda *a, **kw: MagicMock(returncode=1, stdout="", stderr=""))
+def _seed(cache, mapping):
+    cache.write_text(json.dumps(mapping, indent=2))
+    registry._cache = None
+
+
+class TestEmptyRegistry:
+    def test_no_cache_is_empty(self):
+        # No discovery has run → empty, no hardcoded fallback.
+        assert registry.available() == {}
+
+    def test_resolve_returns_none_when_empty(self):
+        assert registry.resolve("geno-loops") is None
+        assert registry.resolve("loops") is None
+
+    def test_no_fallback_attribute(self):
+        # The hardcoded fallback dict is gone.
+        assert not hasattr(registry, "_FALLBACK")
+
+
+class TestCacheRoundTrip:
+    def test_write_then_available(self):
+        registry.write_cache({
+            "geno-loops": {"url": "https://github.com/42euge/geno-loops.git",
+                           "source": "github:42euge"},
+        })
         repos = registry.available()
-        assert "geno-agents" in repos
-        assert "geno-dev" in repos
+        assert repos == {"geno-loops": "https://github.com/42euge/geno-loops.git"}
 
-    def test_fallback_keys_have_geno_prefix(self, monkeypatch):
-        monkeypatch.setattr("subprocess.run",
-                            lambda *a, **kw: MagicMock(returncode=1))
-        for name in registry.available():
-            assert name.startswith("geno-"), f"fallback key {name!r} missing geno- prefix"
+    def test_accepts_plain_string_values(self, _temp_cache):
+        _seed(_temp_cache, {"geno-dev": "https://github.com/42euge/geno-dev.git"})
+        assert registry.available()["geno-dev"].endswith("geno-dev.git")
 
-    def test_fallback_values_are_git_urls(self, monkeypatch):
-        monkeypatch.setattr("subprocess.run",
-                            lambda *a, **kw: MagicMock(returncode=1))
-        for url in registry.available().values():
-            assert url.endswith(".git"), f"url {url!r} should end with .git"
-
-
-class TestDiscover:
-    def test_discover_parses_gh_output(self, monkeypatch):
-        fake_repos = [
-            {"name": "geno-dev", "url": "https://github.com/42euge/geno-dev"},
-            {"name": "geno-iso", "url": "https://github.com/42euge/geno-iso"},
-            {"name": "not-geno", "url": "https://github.com/42euge/not-geno"},
-            {"name": "geno-tools", "url": "https://github.com/42euge/geno-tools"},
-        ]
-        result = MagicMock(returncode=0, stdout=json.dumps(fake_repos))
-        monkeypatch.setattr("subprocess.run", lambda *a, **kw: result)
-
-        repos = registry.available()
-        assert "geno-dev" in repos
-        assert "geno-iso" in repos
-        assert "not-geno" not in repos
-        assert "geno-tools" not in repos  # EXCLUDE
-
-    def test_discover_appends_dot_git(self, monkeypatch):
-        fake = [{"name": "geno-dev", "url": "https://github.com/42euge/geno-dev"}]
-        result = MagicMock(returncode=0, stdout=json.dumps(fake))
-        monkeypatch.setattr("subprocess.run", lambda *a, **kw: result)
-
-        repos = registry.available()
-        assert repos["geno-dev"].endswith(".git")
+    def test_malformed_cache_is_empty(self, _temp_cache):
+        _temp_cache.write_text("{ not json")
+        registry._cache = None
+        assert registry.available() == {}
 
 
 class TestResolve:
-    def test_resolve_full_name(self, monkeypatch):
-        monkeypatch.setattr("subprocess.run",
-                            lambda *a, **kw: MagicMock(returncode=1))
-        url = registry.resolve("geno-agents")
-        assert url is not None
-        assert "geno-agents" in url
+    @pytest.fixture(autouse=True)
+    def _seeded(self):
+        registry.write_cache({
+            "geno-agents": {"url": "https://github.com/42euge/geno-agents.git"},
+            "geno-loops": {"url": "https://github.com/42euge/geno-loops.git"},
+        })
 
-    def test_resolve_bare_slug(self, monkeypatch):
-        monkeypatch.setattr("subprocess.run",
-                            lambda *a, **kw: MagicMock(returncode=1))
-        url = registry.resolve("agents")
-        assert url is not None
-        assert "geno-agents" in url
+    def test_resolve_full_name(self):
+        assert registry.resolve("geno-loops") == "https://github.com/42euge/geno-loops.git"
 
-    def test_resolve_unknown_returns_none(self, monkeypatch):
-        monkeypatch.setattr("subprocess.run",
-                            lambda *a, **kw: MagicMock(returncode=1))
+    def test_resolve_bare_slug(self):
+        # backwards-compat: bare slug resolves to geno-<slug>
+        assert registry.resolve("agents") == "https://github.com/42euge/geno-agents.git"
+
+    def test_resolve_unknown_full_returns_none(self):
         assert registry.resolve("geno-nonexistent") is None
 
-    def test_resolve_bare_unknown_returns_none(self, monkeypatch):
-        monkeypatch.setattr("subprocess.run",
-                            lambda *a, **kw: MagicMock(returncode=1))
+    def test_resolve_unknown_bare_returns_none(self):
         assert registry.resolve("nonexistent") is None


### PR DESCRIPTION
**Fixes `geno-tools install geno-loops` failing / geno-loops missing from `ls --available`.**

## Root cause
The registry hardcoded a `_FALLBACK` of 7 repos and tried to discover via `gh repo list` — but `gh` is unauthenticated here, so it silently fell back to the stale 7, which never included geno-loops (one of **23 public geno-* repos**). The hardcode masked broken discovery and was perpetually incomplete — the anti-pattern for a meta-ecosystem.

## Change: discover, don't hardcode
- **`registry.py`** — delete `_FALLBACK` *and* the `gh` shell-out. `available()` reads `~/.geno/registry.json` (the discovery cache); empty when discovery hasn't run — **no fake data**. Adds `read_cache()`/`write_cache()`; `resolve()` behavior unchanged (full name + bare slug).
- **`commands.py`** — `ls --available` and `_resolve_source` point the user at `/geno-tools-meta-ecosystem-discover` when the cache is empty / a name is unknown. **Git-URL install always works** (the unblock).
- **discover skill** — reworked to drive an agent using **only unauthenticated `curl` (public GitHub API) + web search** — no gh, no token, no MCP. Lists geno-* repos, probes each for a top-level SKILL.md, writes `~/.geno/registry.json`. Read-only; never clones/installs. Documents the public-only boundary (private repos → install by URL).

## Verified end-to-end
curl finds **23 public geno-* repos incl geno-loops** → cache written → `ls --available` lists them → `resolve('geno-loops')` and bare `resolve('loops')` work → empty cache shows the discover hint.

## Tests
Rewrote `test_registry.py` for the cache model (empty / roundtrip / resolve / malformed); swapped the dead discovery-source resolve test for cache-resolve + unknown-name-error. **147 pass**; 3 failures are pre-existing on main (`init-geno-dir.sh`, session hook, version-match).

## Follow-up (noted, not in this PR)
`discovery.py`'s github provider still shells to `gh` for the configured-sources/enterprise path. Left as-is; the curl agent is the default public path. Rip gh out of providers too if you want it fully gone.