### PR TITLE
feat(ls): show version + commit, and --check vs remote main

### DIFF
--- a/geno_tools/cli.py
+++ b/geno_tools/cli.py
@@ -9,8 +9,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--version", action="version", version=f"geno-tools {__version__}")
     sub = parser.add_subparsers(dest="cmd", required=True)
 
-    p_ls = sub.add_parser("ls", help="list installed skillsets and their active variant")
+    p_ls = sub.add_parser("ls", help="list installed skillsets with version + commit")
     p_ls.add_argument("--available", action="store_true", help="list registry")
+    p_ls.add_argument("--check", action="store_true",
+                      help="check each installed skillset against its remote (network)")
 
     p_install = sub.add_parser("install", help="install a skillset")
     p_install.add_argument("name", help="full repo name (e.g. geno-<name>), git URL, or local path")

--- a/geno_tools/commands.py
+++ b/geno_tools/commands.py
@@ -64,10 +64,76 @@ def _ls(args: argparse.Namespace) -> int:
         return 0
 
     for full in installed:
-        active = paths.skillset_active(full)
-        target = active.readlink().name if active.is_symlink() else "?"
-        print(f"  {full:<24} active: {target}")
+        info = _skillset_status(full, check_remote=getattr(args, "check", False))
+        line = f"  {full:<22} {info['version']:<8} {info['variant']}@{info['commit']}"
+        if info["state"]:
+            line += f"  {info['state']}"
+        print(line)
+    if not getattr(args, "check", False):
+        print("  (use --check to compare against each remote main)")
     return 0
+
+
+def _skillset_status(full: str, *, check_remote: bool) -> dict:
+    """Version + active variant + short commit + (optionally) remote drift.
+
+    state is "" without --check; with --check it's one of: in-sync, behind,
+    ahead, diverged, dirty, or offline.
+    """
+    active = paths.skillset_active(full)
+    variant = active.readlink().name if active.is_symlink() else "?"
+    worktree = paths.skillset_worktree(full, variant)
+
+    version = str(_read_manifest(full).get("version", "?"))
+
+    def _git(*args) -> str:
+        try:
+            return subprocess.check_output(
+                ["git", "-C", str(worktree), *args],
+                text=True, stderr=subprocess.DEVNULL,
+            ).strip()
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return ""
+
+    commit = _git("rev-parse", "--short", "HEAD") or "?"
+    state = ""
+
+    # `active -> <variant>` is always a symlink; dev mode is when the *worktree*
+    # itself is a symlink to a local checkout. Only skip the remote check then.
+    if check_remote and not worktree.is_symlink():
+        if _git("status", "--porcelain"):
+            state = "dirty"
+        else:
+            branch = _git("branch", "--show-current") or "main"
+            remote = ""
+            try:
+                out = subprocess.check_output(
+                    ["git", "-C", str(worktree), "ls-remote", "origin",
+                     f"refs/heads/{branch}"],
+                    text=True, stderr=subprocess.DEVNULL, timeout=10,
+                ).strip()
+                remote = out.split()[0] if out else ""
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+                state = "offline"
+            if remote:
+                local = _git("rev-parse", "HEAD")
+
+                def _ancestor(a: str, b: str) -> bool:
+                    return subprocess.call(
+                        ["git", "-C", str(worktree), "merge-base",
+                         "--is-ancestor", a, b],
+                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) == 0
+
+                if remote == local:
+                    state = "in-sync"
+                elif _ancestor(local, remote):
+                    state = f"behind ({remote[:7]})"
+                elif _ancestor(remote, local):
+                    state = "ahead"
+                else:
+                    state = "diverged"
+
+    return {"version": version, "variant": variant, "commit": commit, "state": state}
 
 
 # ── manifest ───────────────────────────────────────────────────────────────

--- a/skills/manager/ls/SKILL.md
+++ b/skills/manager/ls/SKILL.md
@@ -12,6 +12,13 @@ metadata:
 # manager/ls — list skillsets
 
 ```
-geno-tools ls               # installed skillsets + active variant
-geno-tools ls --available   # all skillsets in the registry
+geno-tools ls               # installed: version · variant@commit
+geno-tools ls --check       # also compare each to its remote main (network)
+geno-tools ls --available   # all discoverable skillsets in the registry cache
 ```
+
+Plain `ls` shows each installed skillset's declared version (`genotools.yaml`),
+active variant, and short commit — no network. `--check` adds a state column:
+`in-sync`, `behind (<remote-sha>)`, `ahead`, `diverged`, `dirty`, or `offline`,
+so you can see which skillsets `geno-tools update` would advance.
+

--- a/skills/manager/status/SKILL.md
+++ b/skills/manager/status/SKILL.md
@@ -12,6 +12,12 @@ metadata:
 
 # manager/status — ecosystem status
 
-Report, per installed skillset: declared version (`genotools.yaml`), current
-commit + branch, and whether the worktree is behind its remote. Surfaces which
-skillsets need `geno-tools update`.
+Per installed skillset: declared version (`genotools.yaml`), active variant +
+commit, and drift vs the remote (in-sync / behind / ahead / diverged / dirty).
+This is exactly what `manager/ls --check` reports — run:
+
+```
+geno-tools ls --check
+```
+
+Surfaces which skillsets `geno-tools update` would advance.

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -276,6 +276,28 @@ class TestLs:
         assert "geno-dev" in out
         assert "geno-agents" in out
 
+    def test_ls_shows_version_and_check_hint(self, fake_skillset, capsys, monkeypatch):
+        monkeypatch.setattr("geno_tools.registry._cache", {})
+        root = fake_skillset("geno-dev")
+        (root / "main" / "genotools.yaml").write_text('version: "0.4.2"\n')
+        from geno_tools.cli import main
+        rc = main(["ls"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "geno-dev" in out
+        assert "0.4.2" in out          # version from genotools.yaml
+        assert "--check" in out        # hint shown without --check
+
+    def test_skillset_status_degrades_without_git(self, fake_skillset, monkeypatch):
+        # fixture has only a fake .git dir; status must not raise, commit "?".
+        monkeypatch.setattr("geno_tools.registry._cache", {})
+        root = fake_skillset("geno-dev")
+        (root / "main" / "genotools.yaml").write_text('version: "0.4.2"\n')
+        info = commands._skillset_status("geno-dev", check_remote=True)
+        assert info["variant"] == "main"
+        assert info["commit"] == "?"   # no real git history
+        assert info["version"] == "0.4.2"
+
     def test_ls_available_shows_registry(self, monkeypatch, capsys):
         monkeypatch.setattr("geno_tools.registry._cache", {
             "geno-dev": "https://example.com/geno-dev.git",


### PR DESCRIPTION
`geno-tools ls` showed only `active: main` per skillset. Now it surfaces what you actually want — **what version is installed and whether main has moved ahead**.

## Plain `ls` (fast, no network)
```
  geno-loops    0.2.0    main@94eba89
  geno-notes    0.1.0    main@e84fa17
  (use --check to compare against each remote main)
```
Declared version (`genotools.yaml`) · active variant · short commit.

## `ls --check` (compares to each remote main)
Adds a state column: **in-sync / behind (\<remote-sha>) / ahead / diverged / dirty / offline** — so you can see which skillsets `geno-tools update` would advance.
```
  geno-loops    0.2.0    main@94eba89  in-sync
  geno-notes    0.1.0    main@5f3fb1f  behind (e84fa17)
```

## How
- `commands.py`: new `_skillset_status()` — version + `variant@commit`, plus optional remote drift via `git ls-remote` + `merge-base --is-ancestor`. Dev-mode worktrees (symlinked local checkouts) skip the remote check; network failures → `offline`, never raise.
- `cli.py`: `ls --check` flag.
- `manager/ls` + `manager/status` skills updated — `status` now points at `ls --check` (they described the same job).
- Tests: version + hint shown; status degrades gracefully without real git.

Verified live: both installed skillsets `in-sync`; `behind (<sha>)` triggers when local is a commit back. **149 pass**; 3 failures pre-existing on main (init script, session hook, version-match).