### PR TITLE
chore(geno-audit): bring geno-tools into ecosystem compliance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,1 @@
-# geno-tools
-
-Agent-agnostic meta package manager for AI coding agents.
-
-This file is the single source of agent instructions for every coding agent
-(Claude Code, Codex, Antigravity CLI, Cursor, OpenCode). `AGENTS.md` and
-`CLAUDE.md` are kept byte-for-byte identical — a test enforces it. Edit one,
-copy to the other.
+@import GENO.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,1 @@
-# geno-tools
-
-Agent-agnostic meta package manager for AI coding agents.
-
-This file is the single source of agent instructions for every coding agent
-(Claude Code, Codex, Antigravity CLI, Cursor, OpenCode). `AGENTS.md` and
-`CLAUDE.md` are kept byte-for-byte identical — a test enforces it. Edit one,
-copy to the other.
+@./GENO.md

--- a/GENO.md
+++ b/GENO.md
@@ -1,0 +1,127 @@
+# geno-tools — meta-CLI for the geno-* ecosystem
+
+`geno-tools` is the installer, manager, and compliance auditor for geno-* skillsets. It clones repos, sets up Python venvs, materializes bin symlinks, and registers skills with every supported coding agent in one command.
+
+## Skills
+
+| Skill | Category | Slash command |
+|-------|----------|---------------|
+| geno-tools | — | — (umbrella) |
+| geno-tools-manager-status | manager | /geno-tools-manager-status |
+| geno-tools-manager-discover | manager | /geno-tools-manager-discover |
+| geno-tools-manager-install | manager | /geno-tools-manager-install |
+| geno-tools-manager-remove | manager | /geno-tools-manager-remove |
+| geno-tools-manager-upgrade | manager | /geno-tools-manager-upgrade |
+| geno-tools-manager-update | manager | /geno-tools-manager-update |
+| geno-tools-manager-deps | manager | /geno-tools-manager-deps |
+| geno-tools-manager-doctor | manager | /geno-tools-manager-doctor |
+| geno-tools-audit-run | audit | /geno-tools-audit-run |
+| geno-tools-meta-harness-fork | meta/harness | /geno-tools-meta-harness-fork |
+| geno-tools-meta-harness-use | meta/harness | /geno-tools-meta-harness-use |
+| geno-tools-meta-harness-promote | meta/harness | /geno-tools-meta-harness-promote |
+| geno-tools-meta-ecosystem-discover | meta/ecosystem | /geno-tools-meta-ecosystem-discover |
+| geno-tools-meta-ecosystem-scan | meta/ecosystem | /geno-tools-meta-ecosystem-scan |
+| geno-tools-meta-ecosystem-onboarding | meta/ecosystem | /geno-tools-meta-ecosystem-onboarding |
+| geno-tools-author-skill | author | /geno-tools-author-skill |
+| geno-tools-author-repo | author | /geno-tools-author-repo |
+| geno-tools-setup | — | /geno-tools-setup |
+
+## Repo structure
+
+```
+geno-tools/
+├── GENO.md              # agent instructions (this file)
+├── CLAUDE.md            # Claude Code pointer → @./GENO.md
+├── AGENTS.md            # Codex/OpenCode pointer → @import GENO.md
+├── SKILL.md             # umbrella skill manifest
+├── SKILLS.md            # nesting standard documentation
+├── genotools.yaml       # geno-tools manifest (name, version, description)
+├── pyproject.toml       # Python package (geno_tools)
+├── package.json         # Claude Code plugin manifest (skills array)
+├── plugin.json          # Claude Code plugin entrypoint
+├── gemini-extension.json # Gemini CLI extension manifest
+├── geno_tools/          # Python CLI package
+│   ├── __init__.py      #   version: __version__
+│   ├── __main__.py      #   python -m geno_tools entrypoint
+│   ├── cli.py           #   Click CLI root (geno-tools [cmd])
+│   ├── commands.py      #   install, remove, upgrade, update, status, discover, deps
+│   ├── audit.py         #   deterministic audit engine (FAIL/WARN/INFO checks)
+│   ├── discovery.py     #   GitHub-driven registry discovery
+│   ├── docs.py          #   SKILL.md-driven docs compilation
+│   ├── registry.py      #   skillset registry (resolve name → URL)
+│   ├── paths.py         #   ~/.geno/ path constants
+│   ├── config.py        #   config.yaml reader
+│   └── trace.py         #   geno-trace emit
+├── skills/              # skill definitions (category tree)
+│   ├── geno-tools/      #   umbrella
+│   ├── manager/         #   install/remove/upgrade/update/status/discover/deps/doctor
+│   ├── audit/run/       #   ecosystem compliance auditor
+│   ├── meta/harness/    #   fork · use · promote
+│   ├── meta/ecosystem/  #   discover · scan · onboarding
+│   ├── author/          #   skill · repo scaffolding
+│   └── setup/           #   one-time install
+├── docs/                # MkDocs Material site
+├── tests/               # pytest suite
+└── .specs/              # GOALS.md, TENETS.md, VISION.md
+```
+
+## Conventions
+
+### Command prefix aliasing
+
+Skills in this repo always use the canonical `geno-` prefix (e.g. `/geno-tools-manager-install`). The prefix users type (`/gt-`, `/geno-`, or bare `/`) is configured per-installation in `~/.geno/config.yaml` and applied by `geno-tools install`. Never hardcode an aliased prefix like `/gt-` in any committed file.
+
+### Versioning
+
+The single source of version truth is `genotools.yaml`. The following files must all match it:
+
+- `pyproject.toml` → `project.version`
+- `geno_tools/__init__.py` → `__version__`
+- `SKILL.md` frontmatter → `metadata.version`
+
+Bump the version when adding or removing skills, or when changing behavior. Use semver: MAJOR.MINOR.PATCH.
+
+### Agent instruction files
+
+`CLAUDE.md` contains `@./GENO.md` and `AGENTS.md` contains `@import GENO.md` — both are thin pointers so every agent reads this file. After editing `GENO.md`, no copy step is needed: the pointers resolve at agent load time.
+
+### Adding a new skill
+
+1. Create `skills/<category>/<name>/SKILL.md` with frontmatter (`name`, `description`, `allowed-tools`, `license`, `metadata.version`).
+2. The `name` must be the fully-qualified dotted-by-hyphen path: `geno-tools-<category>-<name>`.
+3. Update the Skills table in this file.
+4. Update the umbrella `SKILL.md` description to mention the new slash command.
+5. Bump the version in `genotools.yaml`, `pyproject.toml`, `geno_tools/__init__.py`, and root `SKILL.md` metadata.
+6. Add CLI subcommand in `geno_tools/commands.py` if the skill has a backing command.
+
+### Single source of truth
+
+Ecosystem-wide conventions (nomenclature, required files, SKILL.md format) are defined in the geno-tools audit spec (`skills/audit/run/SKILL.md`) and docs — not in this file. This GENO.md describes this repo; the audit skill describes the ecosystem.
+
+## CLI
+
+Entry point: `geno-tools = "geno_tools.cli:main"`
+
+| Command | Description |
+|---------|-------------|
+| `geno-tools status` | Installed skillsets: version, commit, drift vs main |
+| `geno-tools discover` | Installable skillsets, grouped by category |
+| `geno-tools install <repo>` | Clone, venv, register with all agents |
+| `geno-tools remove <repo>` | Uninstall from all agents |
+| `geno-tools upgrade [repo]` | Pull latest + re-register |
+| `geno-tools update` | Update geno-tools itself to latest version |
+| `geno-tools deps <repo>` | Dependency tree |
+| `geno-tools audit [path]` | Run ecosystem compliance audit |
+| `geno-tools doctor` | Diagnose installation issues |
+
+## Architecture
+
+`geno-tools install` flow: resolve the repo name via `registry.py` → `git clone` into `~/.geno/geno-{name}/main/` → create venv if `genotools.yaml` has a `venv` section → materialize `runtime` bin symlinks → run `npx skills add` (or equivalent) to register skills with each agent.
+
+The audit engine (`audit.py`) runs deterministic checks at three tiers — FAIL (blocks install), WARN (recommended), INFO (advisory) — and returns structured results that the `audit/run` skill then interprets and remediates.
+
+## Dependencies and runtime
+
+- **Python >= 3.10**
+- **Node.js** for `npx skills add` (skill registration)
+- **git** for clone/fetch operations

--- a/tests/test_agent_docs.py
+++ b/tests/test_agent_docs.py
@@ -1,9 +1,11 @@
 """Tests for the root agent instruction files.
 
-The repo keeps exactly two agent-instruction files at the root — AGENTS.md
-(read by Codex, Cursor, OpenCode, …) and CLAUDE.md (read by Claude Code).
-They MUST be byte-for-byte identical so every agent sees the same guidance.
-Edit one, copy it to the other.
+The repo keeps GENO.md as the single source of agent instructions. Per-agent
+pointer files resolve to it at load time:
+  - CLAUDE.md  → "@./GENO.md"      (Claude Code pointer syntax)
+  - AGENTS.md  → "@import GENO.md" (Codex / OpenCode pointer syntax)
+
+Adding GEMINI.md with "@./GENO.md" is recommended but not yet required.
 """
 
 from __future__ import annotations
@@ -13,21 +15,23 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-AGENT_DOCS = ("AGENTS.md", "CLAUDE.md")
 
 
-@pytest.mark.parametrize("name", AGENT_DOCS)
-def test_agent_doc_exists_and_nonempty(name):
+def test_geno_md_exists_and_nonempty():
+    path = REPO_ROOT / "GENO.md"
+    assert path.is_file(), "GENO.md is missing from the repo root"
+    assert path.read_bytes().strip(), "GENO.md is empty"
+
+
+@pytest.mark.parametrize("name,expected", [
+    ("CLAUDE.md", "@./GENO.md"),
+    ("AGENTS.md", "@import GENO.md"),
+])
+def test_agent_pointer_files(name, expected):
     path = REPO_ROOT / name
     assert path.is_file(), f"{name} is missing from the repo root"
-    assert path.read_bytes().strip(), f"{name} is empty"
-
-
-def test_agent_docs_are_identical():
-    contents = {name: (REPO_ROOT / name).read_bytes() for name in AGENT_DOCS}
-    a, c = contents["AGENTS.md"], contents["CLAUDE.md"]
-    assert a == c, (
-        "AGENTS.md and CLAUDE.md must be byte-for-byte identical. "
-        "Edit one and copy it to the other.\n"
-        f"AGENTS.md: {len(a)} bytes, CLAUDE.md: {len(c)} bytes."
+    content = path.read_text().strip()
+    assert content == expected, (
+        f"{name} must contain only '{expected}' (a pointer to GENO.md). "
+        f"Got: {content!r}"
     )


### PR DESCRIPTION
## Audit Report: geno-tools

Automated compliance audit via `geno-audit`.

### Summary

```
  PASS: 11    FAIL: 0 fixed    WARN: 1 fixed    INFO: 1 (advisory)
```

### Audit run (before fix)

```
audit · geno-tools
  [WARN] GENO.md (single source of truth)    ← fixed
  [INFO] library-capable (importable package)  yes
  [ OK ] manifest name  geno-tools
  [ OK ] manifest version is semver  0.6.0
  [ OK ] pyproject version  0.6.0
  [ OK ] __init__ version  0.6.0
  [ OK ] umbrella SKILL.md name  geno-tools
  [ OK ] SKILL.md version  0.6.0
  [ OK ] CLI ↔ sub-skills  16 subcommands · 19 sub-skills
  [ OK ] CLAUDE.md present
  [ OK ] AGENTS.md present
  [ OK ] Claude Code plugin manifest
```

### Audit run (after fix)

```
audit · geno-tools
  [INFO] library-capable (importable package)  yes
  [ OK ] manifest name  geno-tools
  [ OK ] manifest version is semver  0.6.0
  [ OK ] pyproject version  0.6.0
  [ OK ] __init__ version  0.6.0
  [ OK ] umbrella SKILL.md name  geno-tools
  [ OK ] SKILL.md version  0.6.0
  [ OK ] CLI ↔ sub-skills  16 subcommands · 19 sub-skills
  [ OK ] GENO.md (single source of truth)
  [ OK ] CLAUDE.md present
  [ OK ] AGENTS.md present
  [ OK ] Claude Code plugin manifest
------------------------------------------------
  compliant
```

### Changes

**Agent Instruction Files**
- `GENO.md` — created: complete agent instructions (skills table, repo structure, conventions, CLI reference, architecture overview)
- `CLAUDE.md` — replaced full content with `@./GENO.md` pointer (Claude Code pointer syntax)
- `AGENTS.md` — replaced full content with `@import GENO.md` pointer (Codex/OpenCode pointer syntax)

**Tests**
- `tests/test_agent_docs.py` — replaced byte-identity check with pointer-format checks; added GENO.md existence + non-empty test

### Remaining items

None — all audit checks pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VT5rM3F4oxsbqbzaiJsMoN)_