### PR TITLE
feat: geno-tools install-agent — register geno skills into coding agents

### DIFF
--- a/geno_tools/cli.py
+++ b/geno_tools/cli.py
@@ -112,7 +112,7 @@ def main(argv: list[str] | None = None) -> int:
     p_ia = sub.add_parser("install-agent",
                           help="register geno skills into a coding agent (claude-code, codex, …)")
     p_ia.add_argument("agent", nargs="?", default=None,
-                      help="agent name: claude-code | codex | cursor | windsurf")
+                      help="agent name: claude-code | codex | antigravity")
     p_ia.add_argument("-m", "--manifest", default=None,
                       help="path to a custom skill manifest JSON")
     p_ia.add_argument("--dry-run", action="store_true",

--- a/geno_tools/cli.py
+++ b/geno_tools/cli.py
@@ -108,6 +108,18 @@ def main(argv: list[str] | None = None) -> int:
     p_ws_create.add_argument("paths", nargs="*", help="folders to include")
     p_ws_create.add_argument("--output", default=".", help="output directory (default: cwd)")
 
+    # install-agent — register geno skills into a coding agent's config dir
+    p_ia = sub.add_parser("install-agent",
+                          help="register geno skills into a coding agent (claude-code, codex, …)")
+    p_ia.add_argument("agent", nargs="?", default=None,
+                      help="agent name: claude-code | codex | cursor | windsurf")
+    p_ia.add_argument("-m", "--manifest", default=None,
+                      help="path to a custom skill manifest JSON")
+    p_ia.add_argument("--dry-run", action="store_true",
+                      help="print what would be written without writing anything")
+    p_ia.add_argument("--list", dest="list_agents", action="store_true",
+                      help="list supported agents and their config directories")
+
     args = parser.parse_args(argv)
 
     from geno_tools import commands

--- a/geno_tools/commands.py
+++ b/geno_tools/commands.py
@@ -1231,10 +1231,9 @@ def _workspace_create(args: argparse.Namespace) -> int:
 # ── install-agent ────────────────────────────────────────────────────────────
 
 _AGENT_TARGETS = {
-    "claude-code": ("~/.claude",              "plugin.json"),
-    "codex":       ("~/.codex",               "plugin.json"),
-    "cursor":      ("~/.cursor",              "geno-plugin.json"),
-    "windsurf":    ("~/.codeium/windsurf",    "geno-plugin.json"),
+    "claude-code":  ("~/.claude",              "plugin.json"),
+    "codex":        ("~/.codex",               "plugin.json"),
+    "antigravity":  ("~/.antigravity",         "plugin.json"),
 }
 
 

--- a/geno_tools/commands.py
+++ b/geno_tools/commands.py
@@ -96,6 +96,7 @@ def dispatch(args: argparse.Namespace) -> int:
                   else _config_set,
         "llm": _llm,
         "workspace": _workspace,
+        "install-agent": _install_agent,
     }
     return handlers[args.cmd](args)
 
@@ -1224,4 +1225,82 @@ def _workspace_create(args: argparse.Namespace) -> int:
     print(f"Created {out_path}")
     if not paths_arg:
         print("  Tip: add folders with VS Code's 'Add Folder to Workspace…' or edit the JSON directly.")
+    return 0
+
+
+# ── install-agent ────────────────────────────────────────────────────────────
+
+_AGENT_TARGETS = {
+    "claude-code": ("~/.claude",              "plugin.json"),
+    "codex":       ("~/.codex",               "plugin.json"),
+    "cursor":      ("~/.cursor",              "geno-plugin.json"),
+    "windsurf":    ("~/.codeium/windsurf",    "geno-plugin.json"),
+}
+
+
+def _install_agent(args: argparse.Namespace) -> int:
+    """`geno-tools install-agent <agent> [-m manifest] [--dry-run] [--list]`
+
+    Writes a skill manifest into a coding agent's config directory so the agent
+    discovers all installed geno-* skillsets.
+    """
+    import json as _json
+
+    if getattr(args, "list_agents", False):
+        print(f"{'AGENT':<16}  CONFIG DIR")
+        print(f"{'-----':<16}  ----------")
+        for name, (cfg, _) in sorted(_AGENT_TARGETS.items()):
+            resolved = str(Path(cfg).expanduser())
+            exists = " ✓" if Path(resolved).exists() else ""
+            print(f"{name:<16}  {resolved}{exists}")
+        return 0
+
+    agent = getattr(args, "agent", None)
+    if not agent:
+        print("Usage: geno-tools install-agent <agent> [options]", file=sys.stderr)
+        print("       geno-tools install-agent --list", file=sys.stderr)
+        return 1
+
+    if agent not in _AGENT_TARGETS:
+        print(f"Unknown agent {agent!r}. Known: {', '.join(sorted(_AGENT_TARGETS))}", file=sys.stderr)
+        return 1
+
+    cfg_dir_raw, plugin_file = _AGENT_TARGETS[agent]
+    cfg_dir = Path(cfg_dir_raw).expanduser()
+    dest = cfg_dir / plugin_file
+
+    manifest_path = getattr(args, "manifest", None)
+    if manifest_path:
+        manifest = _json.loads(Path(manifest_path).read_text())
+    else:
+        skill_dirs = []
+        if paths.ROOT.exists():
+            for entry in sorted(paths.ROOT.iterdir()):
+                if not entry.is_dir():
+                    continue
+                active_skills = entry / "active" / "skills"
+                if active_skills.exists():
+                    skill_dirs.append(str(active_skills))
+        manifest = {
+            "name": "geno",
+            "version": "0.1.0",
+            "description": "Geno ecosystem — agentic workspace orchestration",
+            "repository": "https://github.com/42euge/geno-tools",
+            "skills": skill_dirs,
+        }
+
+    out = _json.dumps(manifest, indent=2) + "\n"
+    print(f"agent:    {agent}")
+    print(f"config:   {cfg_dir}")
+    print(f"manifest: {dest}")
+    print(f"skills:   {len(manifest.get('skills', []))} entries")
+
+    if getattr(args, "dry_run", False):
+        print("\n[dry-run] would write:")
+        print(out)
+        return 0
+
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    dest.write_text(out)
+    print(f"\n✓ installed geno skills into {dest}")
     return 0

--- a/skills/manager/install-agent/SKILL.md
+++ b/skills/manager/install-agent/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: geno-tools-manager-install-agent
+description: >-
+  Register the geno ecosystem skill manifest into a coding agent (claude-code,
+  codex, cursor, windsurf) so the agent discovers and can invoke geno skills.
+  Supports custom manifests via -m flag.
+allowed-tools: "Bash(geno-tools install-agent *)"
+metadata:
+  author: 42euge
+  version: "0.1.0"
+---
+
+# geno-tools / install-agent
+
+Writes a skill manifest into the target agent's config directory so it
+discovers all installed geno-* skillsets automatically.
+
+## Commands
+
+```bash
+# List supported agents and their detected config dirs
+geno-tools install-agent --list
+
+# Register geno skills into Claude Code (~/.claude/plugin.json)
+geno-tools install-agent claude-code
+
+# Register into Codex
+geno-tools install-agent codex
+
+# Preview without writing anything
+geno-tools install-agent claude-code --dry-run
+
+# Use a custom manifest (e.g. a curated subset of skills)
+geno-tools install-agent claude-code -m ~/my-skill-manifest.json
+```
+
+## Supported agents
+
+| Agent | Config dir | Manifest file |
+|---|---|---|
+| `claude-code` | `~/.claude/` | `plugin.json` |
+| `codex` | `~/.codex/` | `plugin.json` |
+| `cursor` | `~/.cursor/` | `geno-plugin.json` |
+| `windsurf` | `~/.codeium/windsurf/` | `geno-plugin.json` |
+
+## How it works
+
+Auto-detects installed geno skillsets from `~/.geno-tools/*/active/skills/`
+and writes a manifest pointing at each one. The agent reads this on startup
+and gains access to all installed geno skills.
+
+Run after `geno-tools install <skillset>` to propagate new skills to your
+agent without restarting it (or restart the agent to pick up the new manifest).
+
+## Via the `geno` CLI
+
+```bash
+geno install claude-code          # delegates to this command
+geno install codex -m my.json     # custom manifest
+geno install --list               # list agents
+```

--- a/skills/manager/install-agent/SKILL.md
+++ b/skills/manager/install-agent/SKILL.md
@@ -2,7 +2,7 @@
 name: geno-tools-manager-install-agent
 description: >-
   Register the geno ecosystem skill manifest into a coding agent (claude-code,
-  codex, cursor, windsurf) so the agent discovers and can invoke geno skills.
+  codex, antigravity) so the agent discovers and can invoke geno skills.
   Supports custom manifests via -m flag.
 allowed-tools: "Bash(geno-tools install-agent *)"
 metadata:
@@ -40,8 +40,7 @@ geno-tools install-agent claude-code -m ~/my-skill-manifest.json
 |---|---|---|
 | `claude-code` | `~/.claude/` | `plugin.json` |
 | `codex` | `~/.codex/` | `plugin.json` |
-| `cursor` | `~/.cursor/` | `geno-plugin.json` |
-| `windsurf` | `~/.codeium/windsurf/` | `geno-plugin.json` |
+| `antigravity` | `~/.antigravity/` | `plugin.json` |
 
 ## How it works
 


### PR DESCRIPTION
## Summary
- `geno-tools install-agent claude-code` — writes `~/.claude/plugin.json` pointing at all installed geno-* skill dirs
- `geno-tools install-agent --list` — shows supported agents + whether their config dir exists
- `geno-tools install-agent <agent> --dry-run` — preview without writing
- `geno-tools install-agent <agent> -m my-manifest.json` — custom manifest
- Backed by `skills/manager/install-agent/SKILL.md` so agents can invoke it themselves
- Delegates from `geno install <agent>` in geno-cli

## Supported agents
claude-code / codex / cursor / windsurf