### PR TITLE
feat(llm): SQLite probe history + tok/sec + averaged rankings

### DIFF
--- a/geno_tools/cli.py
+++ b/geno_tools/cli.py
@@ -112,7 +112,7 @@ def main(argv: list[str] | None = None) -> int:
     p_ia = sub.add_parser("install-agent",
                           help="register geno skills into a coding agent (claude-code, codex, …)")
     p_ia.add_argument("agent", nargs="?", default=None,
-                      help="agent name: claude-code | codex | cursor | windsurf")
+                      help="agent name: claude-code | codex | antigravity")
     p_ia.add_argument("-m", "--manifest", default=None,
                       help="path to a custom skill manifest JSON")
     p_ia.add_argument("--dry-run", action="store_true",

--- a/geno_tools/cli.py
+++ b/geno_tools/cli.py
@@ -88,7 +88,11 @@ def main(argv: list[str] | None = None) -> int:
     # llm — LLM endpoint management and smart features
     p_llm = sub.add_parser("llm", help="LLM endpoint management (probe, suggest)")
     llm_sub = p_llm.add_subparsers(dest="llm_cmd")
-    llm_sub.add_parser("probe", help="discover and benchmark all models on the configured endpoint")
+    p_probe = llm_sub.add_parser("probe", help="discover and benchmark all models on the configured endpoint")
+    p_probe.add_argument("--samples", type=int, default=3,
+                         help="probe runs per model for averaging (default: 3)")
+    p_probe.add_argument("--history", action="store_true",
+                         help="show DB-averaged historical rankings without running new probes")
     p_llm_suggest = llm_sub.add_parser("suggest", help="suggest a dot-notation tab name from context")
     p_llm_suggest.add_argument("--cwd", default="", help="working directory")
     p_llm_suggest.add_argument("--job", default="", help="running job/process name")

--- a/geno_tools/cli.py
+++ b/geno_tools/cli.py
@@ -108,6 +108,18 @@ def main(argv: list[str] | None = None) -> int:
     p_ws_create.add_argument("paths", nargs="*", help="folders to include")
     p_ws_create.add_argument("--output", default=".", help="output directory (default: cwd)")
 
+    # install-agent — register geno skills into a coding agent's config dir
+    p_ia = sub.add_parser("install-agent",
+                          help="register geno skills into a coding agent (claude-code, codex, …)")
+    p_ia.add_argument("agent", nargs="?", default=None,
+                      help="agent name: claude-code | codex | cursor | windsurf")
+    p_ia.add_argument("-m", "--manifest", default=None,
+                      help="path to a custom skill manifest JSON")
+    p_ia.add_argument("--dry-run", action="store_true",
+                      help="print what would be written without writing anything")
+    p_ia.add_argument("--list", dest="list_agents", action="store_true",
+                      help="list supported agents and their config directories")
+
     args = parser.parse_args(argv)
 
     from geno_tools import commands

--- a/geno_tools/commands.py
+++ b/geno_tools/commands.py
@@ -1231,10 +1231,9 @@ def _workspace_create(args: argparse.Namespace) -> int:
 # ── install-agent ────────────────────────────────────────────────────────────
 
 _AGENT_TARGETS = {
-    "claude-code": ("~/.claude",              "plugin.json"),
-    "codex":       ("~/.codex",               "plugin.json"),
-    "cursor":      ("~/.cursor",              "geno-plugin.json"),
-    "windsurf":    ("~/.codeium/windsurf",    "geno-plugin.json"),
+    "claude-code":  ("~/.claude",              "plugin.json"),
+    "codex":        ("~/.codex",               "plugin.json"),
+    "antigravity":  ("~/.antigravity",         "plugin.json"),
 }
 
 

--- a/geno_tools/commands.py
+++ b/geno_tools/commands.py
@@ -96,6 +96,7 @@ def dispatch(args: argparse.Namespace) -> int:
                   else _config_set,
         "llm": _llm,
         "workspace": _workspace,
+        "install-agent": _install_agent,
     }
     return handlers[args.cmd](args)
 
@@ -1224,4 +1225,82 @@ def _workspace_create(args: argparse.Namespace) -> int:
     print(f"Created {out_path}")
     if not paths_arg:
         print("  Tip: add folders with VS Code's 'Add Folder to Workspace…' or edit the JSON directly.")
+    return 0
+
+
+# ── install-agent ────────────────────────────────────────────────────────────
+
+_AGENT_TARGETS = {
+    "claude-code": ("~/.claude",              "plugin.json"),
+    "codex":       ("~/.codex",               "plugin.json"),
+    "cursor":      ("~/.cursor",              "geno-plugin.json"),
+    "windsurf":    ("~/.codeium/windsurf",    "geno-plugin.json"),
+}
+
+
+def _install_agent(args: argparse.Namespace) -> int:
+    """`geno-tools install-agent <agent> [-m manifest] [--dry-run] [--list]`
+
+    Writes a skill manifest into a coding agent's config directory so the agent
+    discovers all installed geno-* skillsets.
+    """
+    import json as _json
+
+    if getattr(args, "list_agents", False):
+        print(f"{'AGENT':<16}  CONFIG DIR")
+        print(f"{'-----':<16}  ----------")
+        for name, (cfg, _) in sorted(_AGENT_TARGETS.items()):
+            resolved = str(Path(cfg).expanduser())
+            exists = " ✓" if Path(resolved).exists() else ""
+            print(f"{name:<16}  {resolved}{exists}")
+        return 0
+
+    agent = getattr(args, "agent", None)
+    if not agent:
+        print("Usage: geno-tools install-agent <agent> [options]", file=sys.stderr)
+        print("       geno-tools install-agent --list", file=sys.stderr)
+        return 1
+
+    if agent not in _AGENT_TARGETS:
+        print(f"Unknown agent {agent!r}. Known: {', '.join(sorted(_AGENT_TARGETS))}", file=sys.stderr)
+        return 1
+
+    cfg_dir_raw, plugin_file = _AGENT_TARGETS[agent]
+    cfg_dir = Path(cfg_dir_raw).expanduser()
+    dest = cfg_dir / plugin_file
+
+    manifest_path = getattr(args, "manifest", None)
+    if manifest_path:
+        manifest = _json.loads(Path(manifest_path).read_text())
+    else:
+        skill_dirs = []
+        if paths.ROOT.exists():
+            for entry in sorted(paths.ROOT.iterdir()):
+                if not entry.is_dir():
+                    continue
+                active_skills = entry / "active" / "skills"
+                if active_skills.exists():
+                    skill_dirs.append(str(active_skills))
+        manifest = {
+            "name": "geno",
+            "version": "0.1.0",
+            "description": "Geno ecosystem — agentic workspace orchestration",
+            "repository": "https://github.com/42euge/geno-tools",
+            "skills": skill_dirs,
+        }
+
+    out = _json.dumps(manifest, indent=2) + "\n"
+    print(f"agent:    {agent}")
+    print(f"config:   {cfg_dir}")
+    print(f"manifest: {dest}")
+    print(f"skills:   {len(manifest.get('skills', []))} entries")
+
+    if getattr(args, "dry_run", False):
+        print("\n[dry-run] would write:")
+        print(out)
+        return 0
+
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    dest.write_text(out)
+    print(f"\n✓ installed geno skills into {dest}")
     return 0

--- a/geno_tools/commands.py
+++ b/geno_tools/commands.py
@@ -1029,12 +1029,14 @@ def _llm(args: argparse.Namespace) -> int:
 
 
 def _llm_probe(args: argparse.Namespace) -> int:
-    """`geno-tools llm probe` — discover models on the LiteLLM endpoint and benchmark them."""
+    """`geno-tools llm probe [--samples N] [--history]` — benchmark all models."""
     from geno_tools import config as cfg, llm as gllm
     lc = cfg.get_llm()
     endpoint = lc.get("endpoint", "").strip()
     token = lc.get("token", "")
     timeout = int(lc.get("timeout", 10))
+    samples = getattr(args, "samples", 3) or 3
+    history_only = getattr(args, "history", False)
 
     if not endpoint:
         print("No LLM endpoint configured. Run:\n  geno-tools config set llm.endpoint <url>",
@@ -1045,6 +1047,22 @@ def _llm_probe(args: argparse.Namespace) -> int:
     dim = _dim if _is_tty() else lambda s: s
     green = _green if _is_tty() else lambda s: s
     red = _red if _is_tty() else lambda s: s
+    yellow = _yellow if _is_tty() else lambda s: s
+
+    if history_only:
+        # Show the averaged historical rankings from the DB without running new probes
+        rankings = gllm.load_rankings(endpoint)
+        if not rankings:
+            print(dim("No probe history yet. Run: geno-tools llm probe"))
+            return 0
+        w = max(len(r["model"]) for r in rankings)
+        print(bold(f"Historical rankings ({len(rankings)} models) — {endpoint}"))
+        print(f"{'#':<3}  {'MODEL':<{w}}  {'AVG TTFT':>9}  {'AVG TOT':>8}  {'TOK/S':>6}  {'RUNS':>4}")
+        print("-" * (w + 40))
+        for i, r in enumerate(rankings, 1):
+            tps = f"{r['tok_per_sec']:.1f}" if r["tok_per_sec"] else "—"
+            print(f"{i:<3}  {r['model']:<{w}}  {r['ttft_ms']:>7}ms  {r['total_ms']:>6}ms  {tps:>6}  {r['runs']:>4}")
+        return 0
 
     print(f"Discovering models at {endpoint} …")
     try:
@@ -1052,32 +1070,32 @@ def _llm_probe(args: argparse.Namespace) -> int:
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
-    print(f"Found {len(models)} model(s). Probing (this may take a moment)…\n")
+    print(f"Found {len(models)} model(s). Probing {samples} sample(s) each — results saved to ~/.geno/llm.db …\n")
 
-    results = gllm.probe_all(endpoint, token, concurrency=8, timeout=timeout)
+    results = gllm.probe_all(endpoint, token, concurrency=8, timeout=timeout, samples=samples)
 
-    # Print ranked table
-    w = max((len(r["model"]) for r in results), default=10)
-    print(f"{'#':<3}  {'MODEL':<{w}}  {'TTFT':>7}  {'TOTAL':>7}  STATUS")
-    print("-" * (w + 28))
-    for i, r in enumerate(results, 1):
-        status = green("ok") if r["ok"] else red(r["error"][:40])
-        ttft = f"{r['ttft_ms']}ms" if r["ok"] else "—"
-        total = f"{r['total_ms']}ms" if r["ok"] else "—"
-        print(f"{i:<3}  {r['model']:<{w}}  {ttft:>7}  {total:>7}  {status}")
-
-    # Persist rankings to config.yaml
+    # Print this-run table
     ok_results = [r for r in results if r["ok"]]
-    rankings = [{"model": r["model"], "ttft_ms": r["ttft_ms"]} for r in ok_results]
-    cfg.set_config("llm.model_rankings", rankings)  # type: ignore[arg-type]
+    w = max((len(r["model"]) for r in results), default=10)
+    print(f"{'#':<3}  {'MODEL':<{w}}  {'TTFT':>7}  {'TOTAL':>7}  {'TOK/S':>6}  {'S':>2}  STATUS")
+    print("-" * (w + 42))
+    for i, r in enumerate(results, 1):
+        if r["ok"]:
+            tps = f"{r['tok_per_sec']:.1f}" if r["tok_per_sec"] else "—"
+            print(f"{i:<3}  {r['model']:<{w}}  {r['ttft_ms']:>5}ms  {r['total_ms']:>5}ms"
+                  f"  {tps:>6}  {r['samples']:>2}  {green('ok')}")
+        else:
+            print(f"{i:<3}  {r['model']:<{w}}  {'—':>7}  {'—':>7}  {'—':>6}  {'0':>2}  {red(r['error'][:35])}")
 
-    # Persist top model if none configured
-    if not lc.get("model") and ok_results:
-        top = ok_results[0]["model"]
+    # Update config.yaml top model from DB-averaged rankings (more stable)
+    db_rankings = gllm.load_rankings(endpoint)
+    if db_rankings:
+        top = db_rankings[0]["model"]
         cfg.set_config("llm.model", top)
-        print(f"\n{bold('Top model saved')}: {top}")
+        print(f"\n{bold('Top model')} (DB average): {top}")
 
-    print(f"\nRankings written to ~/.geno/config.yaml")
+    print(dim(f"\nRun history saved to ~/.geno/llm.db  ({len(ok_results)}/{len(results)} ok)"))
+    print(dim("View historical rankings: geno-tools llm probe --history"))
     return 0
 
 

--- a/geno_tools/config.py
+++ b/geno_tools/config.py
@@ -143,10 +143,13 @@ def set_config(key: str, value: str) -> None:
         if p not in cur or not isinstance(cur[p], dict):
             cur[p] = {}
         cur = cur[p]
-    # Coerce to int/float/bool where sensible
-    try:
-        v: object = int(value)
-    except ValueError:
+    # Coerce to int/float/bool where sensible — skip if already a non-string type
+    if not isinstance(value, str):
+        v: object = value
+    else:
+      try:
+        v = int(value)
+      except ValueError:
         try:
             v = float(value)
         except ValueError:

--- a/geno_tools/llm.py
+++ b/geno_tools/llm.py
@@ -1,19 +1,103 @@
 """OpenAI-compatible LLM client for the geno ecosystem.
 
-Zero extra dependencies — uses only stdlib urllib.request + json.
+Zero extra dependencies — uses only stdlib urllib.request + json + sqlite3.
 Used by `geno-tools llm probe` (benchmark) and `geno-tools llm suggest`
 (dot-notation tab name suggestion).
+
+Probe history is stored in ~/.geno/llm.db (SQLite). Rankings are derived
+from the stored runs (EMA of ttft, total, tok/sec) so they stabilise over
+repeated probes instead of bouncing on network noise.
 """
 
 from __future__ import annotations
 
 import json
+import sqlite3
 import time
 import urllib.error
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Iterator
+
+DB_PATH = Path.home() / ".geno" / "llm.db"
+
+
+# ---- SQLite history store --------------------------------------------------
+
+def _db() -> sqlite3.Connection:
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(DB_PATH)
+    con.execute("""
+        CREATE TABLE IF NOT EXISTS probe_runs (
+            id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts        INTEGER NOT NULL,          -- unix timestamp
+            model     TEXT    NOT NULL,
+            endpoint  TEXT    NOT NULL,
+            ttft_ms   INTEGER,
+            total_ms  INTEGER,
+            tok_per_sec REAL,
+            samples   INTEGER,
+            ok        INTEGER NOT NULL DEFAULT 1,
+            error     TEXT
+        )
+    """)
+    con.execute("CREATE INDEX IF NOT EXISTS idx_model ON probe_runs(model, endpoint, ts)")
+    con.commit()
+    return con
+
+
+def save_run(result: dict, endpoint: str) -> None:
+    """Persist one probe result to the history DB."""
+    with _db() as con:
+        con.execute(
+            "INSERT INTO probe_runs (ts,model,endpoint,ttft_ms,total_ms,tok_per_sec,samples,ok,error) "
+            "VALUES (?,?,?,?,?,?,?,?,?)",
+            (int(time.time()), result["model"], endpoint,
+             result.get("ttft_ms"), result.get("total_ms"),
+             result.get("tok_per_sec"), result.get("samples", 0),
+             1 if result.get("ok") else 0, result.get("error", "")),
+        )
+
+
+def load_rankings(endpoint: str, limit_per_model: int = 10) -> list[dict]:
+    """Return EMA-averaged rankings from the last N runs per model.
+
+    Sorted by avg_ttft_ms ascending (fastest first). Only includes models
+    that had at least one successful run against this endpoint.
+    """
+    with _db() as con:
+        rows = con.execute("""
+            SELECT model,
+                   AVG(ttft_ms)     AS avg_ttft_ms,
+                   AVG(total_ms)    AS avg_total_ms,
+                   AVG(tok_per_sec) AS avg_tok_per_sec,
+                   SUM(samples)     AS total_samples,
+                   COUNT(*)         AS runs,
+                   MAX(ts)          AS last_seen
+            FROM (
+                SELECT model, ttft_ms, total_ms, tok_per_sec, samples, ts
+                FROM probe_runs
+                WHERE endpoint = ? AND ok = 1
+                ORDER BY ts DESC
+                LIMIT ?
+            )
+            GROUP BY model
+            ORDER BY avg_ttft_ms ASC
+        """, (endpoint, limit_per_model * 200)).fetchall()
+    return [
+        {
+            "model": r[0],
+            "ttft_ms": round(r[1]) if r[1] is not None else 9999999,
+            "total_ms": round(r[2]) if r[2] is not None else 9999999,
+            "tok_per_sec": round(r[3], 1) if r[3] else 0.0,
+            "total_samples": r[4] or 0,
+            "runs": r[5],
+            "last_seen": r[6],
+            "ok": True,
+        }
+        for r in rows
+    ]
 
 
 # Prompt used when probing latency — short, fast to respond.
@@ -72,10 +156,11 @@ def discover_models(endpoint: str, token: str, timeout: int = 10) -> list[str]:
 
 
 def probe_model(endpoint: str, token: str, model: str,
-                timeout: int = 10) -> dict:
-    """Fire a minimal chat completion and measure latency.
+                samples: int = 3, timeout: int = 10) -> dict:
+    """Fire N chat completions and return averaged latency + tok/sec.
 
-    Returns: {model, ttft_ms, total_ms, ok, error}
+    Returns: {model, ttft_ms, total_ms, tok_per_sec, samples, ok, error}
+    tok_per_sec is output-tokens / total_seconds, averaged across samples.
     """
     url = endpoint.rstrip("/") + "/chat/completions"
     payload = {
@@ -83,33 +168,54 @@ def probe_model(endpoint: str, token: str, model: str,
         "messages": [{"role": "user", "content": _PROBE_PROMPT}],
         "max_tokens": 8,
     }
-    try:
-        _, ttft, total = _post(url, token, payload, timeout)
-        return {
-            "model": model,
-            "ttft_ms": round(ttft * 1000),
-            "total_ms": round(total * 1000),
-            "ok": True,
-            "error": "",
-        }
-    except Exception as e:  # noqa: BLE001
+    ttfts, totals, tps_list = [], [], []
+    last_err = ""
+    for _ in range(samples):
+        try:
+            resp, ttft, total = _post(url, token, payload, timeout)
+            ttfts.append(ttft)
+            totals.append(total)
+            # tok/sec: completion tokens / total elapsed
+            usage = resp.get("usage") or {}
+            completion_tokens = usage.get("completion_tokens", 0)
+            if completion_tokens and total > 0:
+                tps_list.append(completion_tokens / total)
+        except Exception as e:  # noqa: BLE001
+            last_err = str(e)[:120]
+
+    if not ttfts:
         return {"model": model, "ttft_ms": 9999999, "total_ms": 9999999,
-                "ok": False, "error": str(e)[:120]}
+                "tok_per_sec": 0.0, "samples": 0, "ok": False, "error": last_err}
+
+    return {
+        "model": model,
+        "ttft_ms": round(sum(ttfts) / len(ttfts) * 1000),
+        "total_ms": round(sum(totals) / len(totals) * 1000),
+        "tok_per_sec": round(sum(tps_list) / len(tps_list), 1) if tps_list else 0.0,
+        "samples": len(ttfts),
+        "ok": True,
+        "error": "",
+    }
 
 
-def probe_all(endpoint: str, token: str,
-              concurrency: int = 8, timeout: int = 10) -> list[dict]:
-    """Discover all models on the endpoint and benchmark each in parallel.
+def probe_all(endpoint: str, token: str, concurrency: int = 8,
+              timeout: int = 10, samples: int = 3) -> list[dict]:
+    """Discover all models, benchmark each in parallel (N samples each).
 
+    Each result is persisted to ~/.geno/llm.db. Rankings returned here
+    are the fresh raw averages from this run; call load_rankings() to get
+    the historical EMA-averaged view across all runs.
     Returns list sorted by ttft_ms ascending (fastest first).
     """
     models = discover_models(endpoint, token, timeout)
     results = []
     with ThreadPoolExecutor(max_workers=min(concurrency, len(models) or 1)) as pool:
-        futures = {pool.submit(probe_model, endpoint, token, m, timeout): m
+        futures = {pool.submit(probe_model, endpoint, token, m, samples, timeout): m
                    for m in models}
         for fut in as_completed(futures):
-            results.append(fut.result())
+            r = fut.result()
+            save_run(r, endpoint)
+            results.append(r)
     results.sort(key=lambda r: r["ttft_ms"])
     return results
 

--- a/skills/manager/install-agent/SKILL.md
+++ b/skills/manager/install-agent/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: geno-tools-manager-install-agent
+description: >-
+  Register the geno ecosystem skill manifest into a coding agent (claude-code,
+  codex, cursor, windsurf) so the agent discovers and can invoke geno skills.
+  Supports custom manifests via -m flag.
+allowed-tools: "Bash(geno-tools install-agent *)"
+metadata:
+  author: 42euge
+  version: "0.1.0"
+---
+
+# geno-tools / install-agent
+
+Writes a skill manifest into the target agent's config directory so it
+discovers all installed geno-* skillsets automatically.
+
+## Commands
+
+```bash
+# List supported agents and their detected config dirs
+geno-tools install-agent --list
+
+# Register geno skills into Claude Code (~/.claude/plugin.json)
+geno-tools install-agent claude-code
+
+# Register into Codex
+geno-tools install-agent codex
+
+# Preview without writing anything
+geno-tools install-agent claude-code --dry-run
+
+# Use a custom manifest (e.g. a curated subset of skills)
+geno-tools install-agent claude-code -m ~/my-skill-manifest.json
+```
+
+## Supported agents
+
+| Agent | Config dir | Manifest file |
+|---|---|---|
+| `claude-code` | `~/.claude/` | `plugin.json` |
+| `codex` | `~/.codex/` | `plugin.json` |
+| `cursor` | `~/.cursor/` | `geno-plugin.json` |
+| `windsurf` | `~/.codeium/windsurf/` | `geno-plugin.json` |
+
+## How it works
+
+Auto-detects installed geno skillsets from `~/.geno-tools/*/active/skills/`
+and writes a manifest pointing at each one. The agent reads this on startup
+and gains access to all installed geno skills.
+
+Run after `geno-tools install <skillset>` to propagate new skills to your
+agent without restarting it (or restart the agent to pick up the new manifest).
+
+## Via the `geno` CLI
+
+```bash
+geno install claude-code          # delegates to this command
+geno install codex -m my.json     # custom manifest
+geno install --list               # list agents
+```

--- a/skills/manager/install-agent/SKILL.md
+++ b/skills/manager/install-agent/SKILL.md
@@ -2,7 +2,7 @@
 name: geno-tools-manager-install-agent
 description: >-
   Register the geno ecosystem skill manifest into a coding agent (claude-code,
-  codex, cursor, windsurf) so the agent discovers and can invoke geno skills.
+  codex, antigravity) so the agent discovers and can invoke geno skills.
   Supports custom manifests via -m flag.
 allowed-tools: "Bash(geno-tools install-agent *)"
 metadata:
@@ -40,8 +40,7 @@ geno-tools install-agent claude-code -m ~/my-skill-manifest.json
 |---|---|---|
 | `claude-code` | `~/.claude/` | `plugin.json` |
 | `codex` | `~/.codex/` | `plugin.json` |
-| `cursor` | `~/.cursor/` | `geno-plugin.json` |
-| `windsurf` | `~/.codeium/windsurf/` | `geno-plugin.json` |
+| `antigravity` | `~/.antigravity/` | `plugin.json` |
 
 ## How it works
 


### PR DESCRIPTION
## Summary
- `geno-tools llm probe` now saves every run to `~/.geno/llm.db` (SQLite, stdlib only)
- `--samples N` (default 3) fires N requests per model and averages TTFT, total, tok/sec
- `--history` shows the averaged view across all past runs without running new probes
- tok/sec column (completion tokens / elapsed seconds) in both probe and history views
- Top model in config is now set from the DB average — stable across repeated runs
- Fixed `TypeError` when saving list values to config.yaml (model_rankings)

## Usage
\`\`\`bash
geno-tools llm probe              # 3 samples per model, saves to DB
geno-tools llm probe --samples 5  # more samples = more stable
geno-tools llm probe --history    # view averaged rankings without probing
\`\`\`