### PR TITLE
feat: add root marketplace.json for Codex plugin discovery

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "geno-tools",
+  "interface": {
+    "displayName": "Geno Ecosystem"
+  },
+  "plugins": [
+    {
+      "name": "geno-tools",
+      "source": {
+        "source": "local",
+        "path": "."
+      },
+      "policy": {
+        "installation": "AVAILABLE"
+      },
+      "category": "Coding"
+    }
+  ]
+}


### PR DESCRIPTION
Codex looks for marketplace.json at repo root with a plugins array. Adds it pointing at the repo itself so 'codex plugin add geno-tools@geno-tools' resolves correctly.