### PR TITLE
fix: codex marketplace plugin source path

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -8,7 +8,7 @@
       "name": "geno-tools",
       "source": {
         "source": "local",
-        "path": "."
+        "path": ".codex-plugin"
       },
       "policy": {
         "installation": "AVAILABLE"


### PR DESCRIPTION
Codex expects source.path to point to a dir containing .codex-plugin/plugin.json. Updated to use '.codex-plugin' so the plugin resolves correctly.