### PR TITLE
fix: top-level plugin.json in plugins/geno-tools/

### DIFF
--- a/plugins/geno-tools/plugin.json
+++ b/plugins/geno-tools/plugin.json
@@ -1,0 +1,41 @@
+{
+  "name": "geno-tools",
+  "version": "0.3.0",
+  "description": "Meta-CLI for installing and managing geno-* skillsets",
+  "author": {
+    "name": "42euge"
+  },
+  "homepage": "https://42euge.github.io/geno-tools",
+  "repository": "https://github.com/42euge/geno-tools",
+  "license": "MIT",
+  "keywords": [
+    "skillsets",
+    "installer",
+    "meta-cli",
+    "geno-ecosystem"
+  ],
+  "skills": [
+    "./skills",
+    "./skills/audit",
+    "./skills/author",
+    "./skills/config",
+    "./skills/llm",
+    "./skills/manager",
+    "./skills/meta/ecosystem",
+    "./skills/meta/harness"
+  ],
+  "interface": {
+    "displayName": "geno-tools",
+    "shortDescription": "Install and manage geno-* skillsets for any coding agent",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Install a geno skillset",
+      "List available skillsets"
+    ]
+  }
+}


### PR DESCRIPTION
Codex marketplace scanner looks for plugin.json directly in source.path, not inside .codex-plugin/.