### PR TITLE
fix: agents marketplace.json — local source format for codex

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,23 +1,19 @@
 {
   "name": "geno-tools",
-  "owner": {
-    "name": "42euge",
-    "url": "https://github.com/42euge"
+  "interface": {
+    "displayName": "Geno Ecosystem"
   },
   "plugins": [
     {
       "name": "geno-tools",
       "source": {
-        "type": "git",
-        "url": "https://github.com/42euge/geno-tools"
+        "source": "local",
+        "path": "./plugins/geno-tools"
       },
-      "description": "Meta-CLI for installing and managing geno-* skillsets — the geno ecosystem orchestrator",
-      "version": "0.1.0",
-      "license": "MIT",
-      "homepage": "https://42euge.github.io/geno-tools",
       "policy": {
         "installation": "AVAILABLE"
-      }
+      },
+      "category": "Coding"
     }
   ]
 }

--- a/plugins/geno-tools/.codex-plugin/plugin.json
+++ b/plugins/geno-tools/.codex-plugin/plugin.json
@@ -14,28 +14,16 @@
     "meta-cli",
     "geno-ecosystem"
   ],
-  "skills": [
-    "./skills",
-    "./skills/audit",
-    "./skills/author",
-    "./skills/config",
-    "./skills/llm",
-    "./skills/manager",
-    "./skills/meta/ecosystem",
-    "./skills/meta/harness"
-  ],
+  "skills": "./skills",
   "interface": {
     "displayName": "geno-tools",
     "shortDescription": "Install and manage geno-* skillsets for any coding agent",
     "category": "Coding",
-    "capabilities": [
-      "Interactive",
-      "Read",
-      "Write"
-    ],
+    "capabilities": [],
     "defaultPrompt": [
       "Install a geno skillset",
       "List available skillsets"
-    ]
+    ],
+    "developerName": "42euge"
   }
 }

--- a/plugins/geno-tools/plugin.json
+++ b/plugins/geno-tools/plugin.json
@@ -14,28 +14,16 @@
     "meta-cli",
     "geno-ecosystem"
   ],
-  "skills": [
-    "./skills",
-    "./skills/audit",
-    "./skills/author",
-    "./skills/config",
-    "./skills/llm",
-    "./skills/manager",
-    "./skills/meta/ecosystem",
-    "./skills/meta/harness"
-  ],
+  "skills": "./skills",
   "interface": {
     "displayName": "geno-tools",
     "shortDescription": "Install and manage geno-* skillsets for any coding agent",
     "category": "Coding",
-    "capabilities": [
-      "Interactive",
-      "Read",
-      "Write"
-    ],
+    "capabilities": [],
     "defaultPrompt": [
       "Install a geno skillset",
       "List available skillsets"
-    ]
+    ],
+    "developerName": "42euge"
   }
 }


### PR DESCRIPTION
Codex reads .agents/plugins/marketplace.json and expects source.source='local' + path. Updated to match working openai-curated format.