### PR TITLE
chore(geno-audit): bring geno-tools into ecosystem compliance

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "geno-tools",
   "description": "Meta-CLI for installing and managing geno-* skillsets \u2014 the geno ecosystem orchestrator",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": {
     "name": "42euge",
     "url": "https://github.com/42euge"

--- a/GENO.md
+++ b/GENO.md
@@ -17,7 +17,12 @@ the full lifecycle of skills across all supported coding agents.
 | geno-tools-manager-update | manager | /geno-tools-manager-update |
 | geno-tools-manager-deps | manager | /geno-tools-manager-deps |
 | geno-tools-manager-doctor | manager | /geno-tools-manager-doctor |
+| geno-tools-manager-install-agent | manager | /geno-tools-manager-install-agent |
 | geno-tools-audit-run | audit | /geno-tools-audit-run |
+| geno-tools-config-set | config | /geno-tools-config-set |
+| geno-tools-config-show | config | /geno-tools-config-show |
+| geno-tools-llm-probe | llm | /geno-tools-llm-probe |
+| geno-tools-llm-suggest | llm | /geno-tools-llm-suggest |
 | geno-tools-meta-harness-fork | meta/harness | /geno-tools-meta-harness-fork |
 | geno-tools-meta-harness-use | meta/harness | /geno-tools-meta-harness-use |
 | geno-tools-meta-harness-promote | meta/harness | /geno-tools-meta-harness-promote |
@@ -45,8 +50,10 @@ geno-tools/
 ├── skills/                    # skill definitions (nested category tree)
 │   ├── geno-tools/SKILL.md    #   umbrella skill
 │   ├── setup/SKILL.md         #   bootstrap / PATH setup
-│   ├── manager/               #   install, remove, upgrade, update, status, discover, deps, doctor
+│   ├── manager/               #   install, remove, upgrade, update, status, discover, deps, doctor, install-agent
 │   ├── audit/                 #   ecosystem compliance auditor
+│   ├── config/                #   set / show — config key management
+│   ├── llm/                   #   probe / suggest — LLM endpoint discovery and naming
 │   ├── meta/harness/          #   fork / use / promote variant loop
 │   ├── meta/ecosystem/        #   discover / scan / onboarding
 │   └── author/                #   scaffold skill and repo

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,7 +7,7 @@ description: >-
 allowed-tools: "Bash(geno-tools *) Bash(python3 -m geno_tools *)"
 metadata:
   author: 42euge
-  version: "0.5.0"
+  version: "0.6.0"
 ---
 
 # geno-tools — Skillset Manager

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "name": "geno-tools",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module"
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "geno-tools",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "description": "Meta-CLI for installing and managing geno-* skillsets",
   "author": {
     "name": "42euge",

--- a/skills/geno-tools/SKILL.md
+++ b/skills/geno-tools/SKILL.md
@@ -24,8 +24,10 @@ which geno-tools >/dev/null 2>&1 || echo "geno-tools CLI not on PATH — run /ge
 
 | Category | Skills |
 |----------|--------|
-| **manager/** | `status` · `discover` · `install` · `remove` · `upgrade` · `update` · `deps` · `doctor` |
+| **manager/** | `status` · `discover` · `install` · `install-agent` · `remove` · `upgrade` · `update` · `deps` · `doctor` |
 | **audit/** | `run` — ecosystem compliance auditor |
+| **config/** | `set` · `show` — read/write config keys in `~/.geno/config.yaml` |
+| **llm/** | `probe` · `suggest` — LLM endpoint discovery and workspace naming |
 | **meta/harness/** | `fork` · `use` · `promote` — variant evaluate/evolve loop |
 | **meta/ecosystem/** | `discover` · `scan` · `onboarding` — find/absorb new skillsets |
 | **author/** | `skill` · `repo` — scaffold a skill / a whole skillset repo |


### PR DESCRIPTION
## Audit Report: geno-tools

Automated compliance audit via `geno-audit`.

### Summary

```
PASS: 35    FAIL: 0 fixed    WARN: 2 fixed    INFO: 4 fixed
```

### Changes

**Section 3 — Versioning (2 WARN → fixed)**
- `package.json`: bumped version from `0.5.0` to `0.6.0` to match `genotools.yaml`
- `SKILL.md` (root): bumped `metadata.version` from `0.5.0` to `0.6.0` to match `genotools.yaml`

**Section 5 / Section 6 — Undocumented skills (4 INFO → fixed)**
- `GENO.md`: added 5 skills that existed on disk but were absent from the skills table:
  - `geno-tools-manager-install-agent` (manager)
  - `geno-tools-config-set` (config)
  - `geno-tools-config-show` (config)
  - `geno-tools-llm-probe` (llm)
  - `geno-tools-llm-suggest` (llm)
- `GENO.md`: updated Repo structure tree to show `config/` and `llm/` skill directories
- `skills/geno-tools/SKILL.md`: updated "Skills by category" table to list the new categories and `install-agent`

### Remaining items

None — all WARN and INFO items resolved. No FAIL items were present.

---

*Generated by the `geno-tools-audit-run` skill. Audit date: 2026-07-10.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPCCU22dvMdfE6Ag5ipY2E)_